### PR TITLE
improve deployment eligibility and headers

### DIFF
--- a/src/docs/reference/deployments.md
+++ b/src/docs/reference/deployments.md
@@ -6,25 +6,21 @@ title: Deployments
 This functionality has been superceded by [bundles](bundles) and [releases](releases).
 :::
 
-A deployment makes [firmware](firmware) available to [devices](devices) associated with the same [product](products) as the deployment and that satisfy the deployment's conditions. Deployments may be configured as active or not. Only active deployments may be considered when Peridio evaluates if an update is available for a device.
+A deployment makes [firmware](firmware) conditionally available to [devices](devices).
 
-## Deployment Eligibility
+## Deployment eligibility
 
-When a device checks for an update, Peridio identifies which deployment is applicable to the requesting device, which dictates which firmware Peridio will respond to the request with. This determination is impacted by the device tags the deployment requires and by the version condition specified by the deployment, if any.
-
-For a device to be eligible for any deployment, the device must not be quarantined.
+When a device checks for an update with [get-device-update](/device-api#devices/operation/get-device-update), Peridio resolves which deployment, if any, is applicable to the requesting device, which dictates which firmware Peridio will respond to the request with.
 
 For a device to be eligible for a particular deployment, the following conditions must be met:
 
-- The deployment and the device are of the same organization.
-- The deployment and the device are of the same product.
 - The deployment is active.
-- The deployment is not quarantined.
-- The device's current firmware's architecture matches the architecture of the deployment's firmware.
-- The device's current firmware's platform matches the platform of the deployment's firmware.
-- The device's current firmware's UUID is not the same as the UUID of the deployment's firmware.
+- The deployment and the device are not quarantined and belong to the same organization and product.
+- The device must have at least the tags the deployment's conditions specify.
+- If the deployment has a version condition, the device's firmware's version must satisfy it.
+- The device's firmware and the deployment's firmware have matching architecture and platforms, but distinct UUIDs.
 
-Peridio tracks metadata about the current firmware of devices. Devices themselves dictate what Peridio considers their current firmware by supplying the `x-peridio-uuid` header to the Peridio Device API [get-device-update](/device-api#devices/operation/get-device-update) endpoint.
+Peridio tracks metadata about the current firmware of devices. Devices dictate what Peridio considers their current firmware by supplying [`x-peridio` headers](/device-api#section/Global-Headers) to the Peridio Device API.
 
 ### Tags
 
@@ -32,4 +28,34 @@ A deployment must specify at least one tag as a condition. A device must have at
 
 ### Version
 
-A deployment may optionally specify a version requirement. When a version is specified as a condition for a deployment, a device must meet meet this version requirement. Firmware versions are [semantic versions](https://semver.org/spec/v2.0.0.html), for examples of what a version condition on a deployment may look like, reference https://hexdocs.pm/elixir/Version.html#module-requirements.
+A deployment may optionally specify a SemVer version requirement. When specified, a device's firmware's version must satisfy the requirement. Firmware versions are [semantic versions](https://semver.org/spec/v2.0.0.html), for examples of what a version condition on a deployment may look like, reference https://hexdocs.pm/elixir/Version.html#module-requirements.
+
+## Quarantine
+
+Deployment's have a boolean `quarantined` field. When `true`, the deployment will not serve updates. Deployments can be automatically quarantined due to failure rate and failure threshold configurations.
+
+## Failure rates and thresholds
+
+Deployments allow you to configure failure rates and thresholds such that devices and deployments can be quarantined automatically in reaction to devices repeatedly asking for the same update from the same deployment via [get-device-update](/device-api#devices/operation/get-device-update).
+
+### Automatically quarantine deployments
+
+|Field|Description|
+|-|-|
+|Failure rate|How many devices can have asked 2 or more times each for the same update from the same deployment within failure rate seconds before the deployment is automatically quarantined.|
+|Failure rate seconds|The duration to use with failure rate.|
+|Failure threshold|How many devices with firmware metadata whose architecture, platform, product, and uuid match that of the deployment's firmware that can be simultaneously quarantined before the deployment is automatically quarantined.|
+
+### Automatically quarantine devices
+
+|Field|Description|
+|-|-|
+|Device failure rate|How many times a device can have asked for the same update from the same deployment within device failure rate seconds before the device is automatically quarantined.|
+|Device failure rate seconds|The duration to use with device failure rate.|
+|Device Failure threshold|How many times total a device can have asked for the same update from the same deployment before the device is automatically quarantined.|
+
+### Clear failure rates and thresholds
+
+- Unquarantining a deployment will cause device update attempts prior to that to be ignored in failure rates and thresholds.
+- Unquarantining a device will cause its update attempts prior to that to be ignored in failure rates and thresholds.
+- [`device.release_changed`](/admin-api#device-events/operation/device-release-changed) and [`device.firmware_changed`](/admin-api#device-events/operation/device-firmware-changed) events cause update attempts prior to them to be ignored in failure rates and thresholds.

--- a/src/docs/reference/devices.md
+++ b/src/docs/reference/devices.md
@@ -11,3 +11,7 @@ Devices can be provisioned ad-hoc or via [just in time provisioning](just-in-tim
 ## Tags
 
 Devices can be associated with tags to achieve logical groupings. These grouping may have external meaning to you, but they may also be used within Peridio to adjust the scope of devices to which a deployment is applicable as part of its configured [conditions](deployments#tags).
+
+## Quarantine
+
+Device's have a boolean `quarantined` field. When `true`, the device is ineligible for updates from releases and deployments. You can quarantine and unquarantine devices with the CLI, admin API, and web console. Devices can be [automatically quarantined](/reference/deployments#automatic-quarantines) by deployments during a [get-device-update](/device-api#devices/operation/get-device-update) request.

--- a/src/openapi/peridio-admin-openapi.yaml
+++ b/src/openapi/peridio-admin-openapi.yaml
@@ -3668,14 +3668,17 @@ components:
       properties:
         data:
           type: object
+          description: Data associated with the `device` event type.
           properties:
             type:
               enum:
                 - checked_for_release
             data:
+              description: Data associated with the `checked_for_release` subevent type.
               type: object
               properties:
                 device:
+                  description: The device that checked for a release.
                   type: object
                   properties:
                     prn:
@@ -3683,12 +3686,16 @@ components:
                     identifier:
                       $ref: "#/components/schemas/device-identifier"
                 release:
-                  type: object
-                  properties:
-                    prn:
-                      $ref: "#/components/schemas/release-prn"
-                    version:
-                      $ref: "#/components/schemas/release-version"
+                  description: The release the device was told was available to update to, or `null` if no release is available.
+                  oneOf:
+                    - type: object
+                      properties:
+                        prn:
+                          $ref: "#/components/schemas/release-prn"
+                        version:
+                          $ref: "#/components/schemas/release-version"
+                    - type: null
+                      description: " "
         inserted_at:
           type: string
           format: date-time
@@ -3706,29 +3713,31 @@ components:
       properties:
         data:
           type: object
+          description: Data associated with the `device` event type.
           properties:
             type:
               enum:
                 - claimed_release
             data:
               type: object
+              description: Data associated with the `claimed_release` subevent type.
               properties:
                 device:
                   type: object
+                  description: The device that claimed the release.
                   properties:
                     prn:
                       $ref: "#/components/schemas/device-prn"
                     identifier:
                       $ref: "#/components/schemas/device-identifier"
                 release:
-                  oneOf:
-                    - type: object
-                      properties:
-                        prn:
-                          $ref: "#/components/schemas/release-prn"
-                        version:
-                          $ref: "#/components/schemas/release-version"
-                    - type: null
+                  type: object
+                  description: The release the device claimed.
+                  properties:
+                    prn:
+                      $ref: "#/components/schemas/release-prn"
+                    version:
+                      $ref: "#/components/schemas/release-version"
         inserted_at:
           type: string
           format: date-time
@@ -3746,6 +3755,7 @@ components:
       properties:
         data:
           type: object
+          description: Data associated with the `device` event type.
           properties:
             type:
               type: string
@@ -3753,9 +3763,11 @@ components:
                 - connected
             data:
               type: object
+              description: Data associated with the `connected` subevent type.
               properties:
                 device:
                   type: object
+                  description: The device that connected.
                   properties:
                     prn:
                       $ref: "#/components/schemas/device-prn"
@@ -3769,8 +3781,13 @@ components:
 
                     - `peridio-release-prn`
                     - `peridio-release-version`
+                    - `x-peridio-architecture` (legacy)
+                    - `x-peridio-platform` (legacy)
+                    - `x-peridio-product` (legacy)
+                    - `x-peridio-uuid` (legacy)
+                    - `x-peridio-version` (legacy)
 
-                    This list can grow, integrations must account for unexpected headers.
+                    This list can grow, integrations must account for unexpected headers. See [Device API global headers](/device-api#section/Global-Headers).
                   type: object
                   example:
                     peridio-release-prn: prn:1:4b8c3b41-f1ce-4c09-83ee-9cb60eb71483:release:d39587b9-4445-4e91-8952-4af83b97fea6
@@ -3792,6 +3809,7 @@ components:
       properties:
         data:
           type: object
+          description: Data associated with the `device` event type.
           properties:
             type:
               type: string
@@ -3799,6 +3817,7 @@ components:
                 - release_changed
             data:
               type: object
+              description: Data associated with the `release_changed` subevent type.
               properties:
                 device:
                   type: object
@@ -3844,6 +3863,7 @@ components:
       type: object
       properties:
         data:
+          description: Data associated with the `webhook` event type.
           type: object
           properties:
             type:
@@ -3852,10 +3872,12 @@ components:
                 - request_failed
             data:
               type: object
+              description: Data associated with the `request_failed` subevent type.
               properties:
                 type:
                   $ref: "#/components/schemas/webhook-request-failed-event-type"
                 data:
+                  description: Data associated with the subevent.
                   oneOf:
                     - $ref: "#/components/schemas/webhook-request-failed-host-resolution-failed-event"
                     - $ref: "#/components/schemas/webhook-request-failed-response-timeout-event"
@@ -3878,12 +3900,14 @@ components:
       properties:
         data:
           type: object
+          description: Data associated with the `webhook` event type.
           properties:
             type:
               enum:
                 - test_fire
             data:
               type: object
+              description: Data associated with the `test_fire` subevent type.
               properties:
                 webhook_prn:
                   $ref: "#/components/schemas/webhook-prn"
@@ -4268,7 +4292,10 @@ webhooks:
     post:
       security: []
       summary: Checked for release
-      description: See the [webhooks reference](/reference/webhooks#supported-events) for a list of supported events.
+      description: |
+        See the [webhooks reference](/reference/webhooks#supported-events) for a list of supported events.
+
+        This event is created when a device checks for an update with [get-update](/device-api#devices/operation/get-update).
       operationId: device-checked-for-release
       tags:
         - Device Events
@@ -4288,7 +4315,10 @@ webhooks:
     post:
       security: []
       summary: Claimed release
-      description: See the [webhooks reference](/reference/webhooks#supported-events) for a list of supported events.
+      description: |
+        See the [webhooks reference](/reference/webhooks#supported-events) for a list of supported events.
+
+        This event is created when a device claims access to a phased release during a [get-update](/device-api#devices/operation/get-update).
       operationId: device-claimed-release
       tags:
         - Device Events
@@ -4308,7 +4338,10 @@ webhooks:
     post:
       security: []
       summary: Connected
-      description: See the [webhooks reference](/reference/webhooks#supported-events) for a list of supported events.
+      description: |
+        See the [webhooks reference](/reference/webhooks#supported-events) for a list of supported events.
+
+        This event is created when a device successfully completes a TLS handshake while connecting to the Peridio Device API.
       operationId: device-connected
       tags:
         - Device Events
@@ -4351,7 +4384,10 @@ webhooks:
     post:
       security: []
       summary: Request failed
-      description: See the [webhooks reference](/reference/webhooks#supported-events) for a list of supported events.
+      description: |
+        See the [webhooks reference](/reference/webhooks#supported-events) for a list of supported events.
+
+        This event is created when an attempt to publish an event via a webhook fails.
       operationId: webhook-request-failed
       tags:
         - Webhook Events

--- a/src/openapi/peridio-device-openapi.yaml
+++ b/src/openapi/peridio-device-openapi.yaml
@@ -15,7 +15,11 @@ info:
     |-|-|-|
     |peridio-release-prn|A release PRN.|See [release resolution](/reference/releases#release-resolution). Informs Peridio of what release is currently active on the device. The preference should always be to supply this header with a valid value. If you supply this header, you should not supply the `peridio-release-version` header.|
     |peridio-release-version|A release version.|See [release resolution](/reference/releases#release-resolution). This header is only used in exceptional cases when you don't have a PRN to supply via `peridio-release-prn`. In that case, you may supply this header and you should not supply the `peridio-release-prn` header.|
-    |x-peridio-uuid|A firmware UUID.|Legacy. See [deployment eligibility](/reference/deployments#deployment-eligibility). The UUID of the device's currently active firmware.|
+    |x-peridio-architecture|A firmware architecture.|Legacy. See [deployment eligibility](/reference/deployments#deployment-eligibility). The architecture of the device's currently active firmware. When supplying any `x-peridio` header, you should supply all `x-peridio` headers.|
+    |x-peridio-platform|A firmware platform.|Legacy. See [deployment eligibility](/reference/deployments#deployment-eligibility). The platform of the device's currently active firmware. When supplying any `x-peridio` header, you should supply all `x-peridio` headers.|
+    |x-peridio-product|A firmware product.|Legacy. See [deployment eligibility](/reference/deployments#deployment-eligibility). The product of the device's currently active firmware. When supplying any `x-peridio` header, you should supply all `x-peridio` headers.|
+    |x-peridio-uuid|A firmware UUID.|Legacy. See [deployment eligibility](/reference/deployments#deployment-eligibility). The UUID of the device's currently active firmware. When supplying any `x-peridio` header, you should supply all `x-peridio` headers.|
+    |x-peridio-version|A firmware version.|Legacy. See [deployment eligibility](/reference/deployments#deployment-eligibility). The version of the device's currently active firmware. When supplying any `x-peridio` header, you should supply all `x-peridio` headers.|
   title: Peridio Device API
   version: "1.0.0"
 servers:


### PR DESCRIPTION
admin api

- Update monitored headers for device.connected event.
- Update events to have more descriptions for fields and to always say when they are created.

device api

- Update global headers with additional x-peridio legacy headers.

reference

- Deployments: eligibility, failure rates and threshold, and quarantines.