### PR TITLE
add google gtag plugin

### DIFF
--- a/src/.prettierrc.json
+++ b/src/.prettierrc.json
@@ -2,5 +2,6 @@
   "trailingComma": "es5",
   "tabWidth": 2,
   "semi": false,
-  "singleQuote": true
+  "singleQuote": true,
+  "printWidth": 100
 }

--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -17,22 +17,28 @@ const config = {
   trailingSlash: false,
   plugins: [
     [
-      '@docusaurus/plugin-content-docs', {
+      '@docusaurus/plugin-content-docs',
+      {
         breadcrumbs: false,
         path: 'docs',
         routeBasePath: '/',
         sidebarPath: require.resolve('./sidebars.js'),
       },
     ],
+    ['@docusaurus/plugin-content-pages', {}],
     [
-      '@docusaurus/plugin-content-pages', {
-
-      },
+      '@docusaurus/plugin-google-gtag',
+      /** @type {import('@docusaurus/plugin-google-gtag').Options} */
+      ({
+        trackingID: 'G-XN33JD9H3F',
+        anonymizeIP: true,
+      }),
     ],
   ],
   themes: [
     [
-      '@docusaurus/theme-classic', {
+      '@docusaurus/theme-classic',
+      {
         customCss: [require.resolve('./src/css/custom.css')],
       },
     ],
@@ -62,7 +68,6 @@ const config = {
             disableSearch: true,
           },
           primaryColor: '#3424ee',
-
         },
       },
     ],


### PR DESCRIPTION
See: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag

> This plugin is always inactive in development and only active in production to avoid polluting the analytics statistics.

Verified `yarn build` succeeds locally. I also bumped the Prettier `printWidth` to 100 as it seems the config hadn't been formatted in a while, and multiple things wanted to wrap without making it a little more generous.