### PR TITLE
refactor docs for bundle distribution clarity

### DIFF
--- a/src/docs/platform/guides/introduction-to-binary-management.md
+++ b/src/docs/platform/guides/introduction-to-binary-management.md
@@ -102,5 +102,4 @@ The above command will:
 
 At this point you will have a signed binary that is ready to be included in [bundles](/platform/reference/bundles) and distributed via [releases](/platform/reference/releases).
 
-To get started on that, checkout the [Introduction to Release
-Management](introduction-to-release-management) guide.
+To get started on that, checkout the [introduction to bundle management](introduction-to-bundle-management) guide.

--- a/src/docs/platform/guides/introduction-to-bundle-management.md
+++ b/src/docs/platform/guides/introduction-to-bundle-management.md
@@ -1,15 +1,15 @@
-# Introduction to release management
+# Introduction to bundle management
 
-This guide serves as a comprehensive introduction to release management that will cover bundles and releases.
+This guide serves as a comprehensive introduction to bundle management that will cover bundles and releases.
 
 ## Prerequisites
 
 - [Peridio CLI](https://github.com/peridio/morel/releases).
   - Last tested with version 0.8.0.
 
-## Release management resources
+## Bundle management resources
 
-Release management comprises the following resources:
+Bundle management comprises the following resources:
 
 - [Bundles](/platform/reference/bundles) - define ordered sets of [binaries](/platform/reference/binaries) that can be distributed to [devices](/platform/reference/devices) via [releases](/platform/reference/releases).
 - [Releases](/platform/reference/releases) - publish bundles to devices and form the [release graph](/platform/reference/releases#graph-traversal).

--- a/src/docs/platform/reference/bundle-distribution.md
+++ b/src/docs/platform/reference/bundle-distribution.md
@@ -1,0 +1,85 @@
+# Bundle distribution
+
+When a device executes a Device API [get-update](/device-api#devices/operation/get-update) request, Peridio performs bundle resolution. Bundle resolution is the process of determing if there is another bundle, referred to as the target bundle, the device can update to. To make this determination, Peridio must know what the device is currently running.
+
+## Bundle resolution
+
+A target bundle is resolved via either bundle overrides or release resolution. The following subsections give a high-level overview of the two resolution methods. For an exhaustive specification of the entire process, refer to the [resolution algorithm](#resolution-algorithm).
+
+### Bundle override method
+
+[Bundle overrides](/platform/reference/bundle-overrides) are higher priority than release resolution. If there is an applicable bundle override, release resolution will not be considered at all. If Peridio Cloud considers a device to be on a different bundle than the applicable override, then when it checks for an update it will be served the override's bundle. If Peridio Cloud considers a device to be on the bundle of the applicable bundle override, then the device will be served no update ignoring any potential releases should they exist. This state will continue until the bundle override is updated, expired, or deleted.
+
+:::tip bundle but no release
+When a device receives a bundle via a bundle override, there is a relevant bundle, but no relevant release.
+
+This requires careful consideration during [device integration](#device-integration).
+:::
+
+### Release resolution method
+
+So long as no bundle override is applicable, and the device belongs to a cohort, release resolution will be executed against the device's cohort's [release channel](release-channels). Release resolution is split into two approaches: PRN resolution and version resolution. These approaches differ in how they identify the device's first candidate release, but they are identical in the resolution algorithm they apply thereafter.
+
+PRN resolution uses the `peridio-release-prn` header to indicate a device's current release exactly, and its next release is the first candidate release.
+
+Version resolution uses the `peridio-release-version` header to indicate a [SemVer](https://semver.org/) version. If the channel contains releases with a `version` and `version_requirement` specified, where the header supplied version satisfies the version requirements, then of those releases the one with the lowest version is considered the first candidate release.
+
+:::tip bundle and release
+When a device receives a bundle via a release, there is both a relevant release and a relevant bundle.
+
+This requires careful consideration during [device integration](#device-integration).
+:::
+
+## Device integration
+
+Whenever a device considers itself to be running a new bundle, it SHOULD inform Peridio Cloud as it will dictate the result of future updates.
+
+### Device HTTP API
+
+When using the Device HTTP API, its [global headers](/device-api#section/Global-Headers) are used to inform Peridio Cloud of what the device is running. After having installed a bundle received via a release or bundle override, supply headers to subsequent requests as specified below.
+
+:::info single source headers
+When supplying multiple headers at once, the values of all headers must be informed by the same singular instance of having received a bundle. This is also why when having received a bundle via bundle override that it is never correct to subsequently supply a `peridio-release-prn`, since there is no relevant release in that case.
+:::
+
+#### Header rules
+
+Bundle received via a [release](releases):
+
+  - `peridio-release-prn` MUST be supplied.
+  - `peridio-bundle-prn` MAY be supplied.
+  - `peridio-release-version` MAY be supplied.
+
+Bundle received via a [bundle override](bundle-overrides):
+
+  - `peridio-release-prn` MUST NOT be supplied.
+  - `peridio-bundle-prn` MUST be supplied.
+  - `peridio-release-version` MAY be supplied.
+
+:::caution releases + bundle overrides
+If a device installed a bundle from a release and subsequently installed a bundle from a bundle override: it is critical that the aforementioned header rules are respected, in particular: a `peridio-release-prn` MUST NOT be supplied.
+:::
+
+#### Header fallbacks
+
+When supplying multiple headers, Peridio prioritizes them in the order noted below. If a supplied header is malformed, or fails to identify a release or bundle in the device's current cohort, the next highest precedence supplied header will be attempted to be used.
+
+  1. `peridio-release-prn`
+  2. `peridio-bundle-prn`
+  3. `peridio-release-version`
+
+**Example 1**
+
+Supplied:
+
+  - `peridio-release-prn` malformed and does not identify a release in the device's current cohort
+  - `peridio-bundle-prn` well formed and does identify a bundle served by a release in the device's current cohort
+  - `peridio-release-version` well formed and does identify a bundle served by a release in the device's current cohort
+
+First, the `peridio-release-prn` header is considered, but is discarded immediately due to being malformed. Second, the `peridio-bundle-prn` is considered, it is well formed, but is discarded still because it fails to identify a bundle served by a release in the device's current cohort. Finally, the `peridio-release-version` is considered, it is well formed, and successfully identifies a release in the device's current cohort.
+
+## Resolution algorithm
+
+Below is a diagram that exhaustively specifies the entire bundle resolution algorithm.
+
+<img src="/img/release-resolution.png" width="auto" />

--- a/src/docs/platform/reference/bundle-overrides.md
+++ b/src/docs/platform/reference/bundle-overrides.md
@@ -1,0 +1,19 @@
+# Bundle overrides
+
+Bundle overrides allow you to force a [device](/platform/reference/devices) to be served a [bundle](/platform/reference/bundles) of your choosing, taking precedence over any [release](/platform/reference/releases) that otherwise would have been relevant for the duration of the override.
+
+## Scheduling
+
+Bundle overrides may be scheduled via start and end datetimes. In order for a bundle override to ever be applicable, it must have a start datetime. End datetimes are optional. A bundle override without an end datetime has a schedule that begins at the start datetime, and never ends.
+
+### Stacking
+
+When multiple bundle overrides' schedules overlap, only a single bundle override is ever applicable at any given moment. The applicable bundle override is always the one whose schedule you are within, and that started most recently.
+
+## Mutability
+
+Bundle overrides may be modified at any time to update their name, description, scheduling, and the bundle they serve.
+
+## Distribution
+
+Bundle overrides, like [releases](releases), are a method of bundle resolution detailed in the [bundle distribution](bundle-distribution) reference.

--- a/src/docs/platform/reference/bundles.md
+++ b/src/docs/platform/reference/bundles.md
@@ -1,5 +1,64 @@
 # Bundles
 
-Bundles are an immutable ordered set of [binaries](binaries). You associate a bundle with a [release](releases) to specify what binaries the release should distribute to [devices](devices). Every release is associated with a single bundle, but a bundle can be associated with any number of releases.
+Bundles are immutable ordered sets of [binaries](binaries) and [custom metadata](#custom-metadata) that can be distributed to devices.
 
-Bundles make it possible to reliably and easily release the same set of binaries across multiple cohorts, empowering common use cases like testing changes against a low risk cohort like engineers' devices, and then later promoting those exact changes to other higher risk cohorts like production devices.
+## Distribution
+
+Bundles may be distributed to devices via [releases](releases) and [bundle overrides](bundle-overrides).
+
+:::tip bundle re-distribution
+A bundle can be configured into an zero to many releases and bundle overrides.
+:::
+
+Bundles enable distributing the exact same set of binaries and custom metadata across multiple devices and cohorts, allowing the cryptographically identical set of assets tested in one place to be tested in another.
+
+For example:
+
+  1. Testing a bundle on a development device via a bundle override.
+  2. Testing the same bundle against staging and nightly cohorts.
+  3. Distributing the same bundle to production cohorts.
+
+This reduces the opportunity for human error that can occur when requiring an asset be rebuilt / redefined when crossing these distribution boundaries.
+
+For a detailed specification, see [bundle distribution](bundle-distribution).
+
+## Custom metadata
+
+Each binary in a bundle can optionally have an arbitrary, user-defined JSON object associated with it. Custom metadata can be specified during bundle creation or defined earlier at various levels: on binaries, artifact versions, or artifacts. Metadata is inherited down this chain, with more specific definitions overriding broader ones.
+
+### Example 1: supplied only on artifact
+
+  - Artifact **(A1)** has custom metadata defined on it.
+  - Artifact Version **(AV1)** for **(A1)** has no custom metadata defined on it.
+  - Binary **(B1)** for **(AV1)** has no custom metadata defined on it.
+  - Creating a bundle with **(B1)**, but supplying no custom metadata.
+
+In the bundle:
+
+  - **(B1)** will have the custom metadata from **(A1)**.
+
+### Example 2: supplied on artifact and binary
+
+  - Artifact **(A1)** has custom metadata defined on it.
+  - Artifact Version **(AV1)** for **(A1)** has no custom metadata defined on it.
+  - Binary **(B1)** for **(AV1)** has no custom metadata defined on it.
+  - Binary **(B2)** for **(AV1)** has custom metadata defined on it.
+  - Creating a bundle with **(B1)** and **(B2)**, but supplying no custom metadata.
+
+In the bundle:
+
+  - **(B1)** will have the custom metadata from **(A1)**.
+  - **(B2)** will have the custom metadata from **(B2)**.
+
+### Example 3: supplied on artifact, binary, and bundle
+
+  - Artifact **(A1)** has custom metadata defined on it.
+  - Artifact Version **(AV1)** for **(A1)** has no custom metadata defined on it.
+  - Binary **(B1)** for **(AV1)** has no custom metadata defined on it.
+  - Binary **(B2)** for **(AV1)** has custom metadata defined on it.
+  - Creating a bundle with **(B1)** and **(B2)**, and supplying custom metadata for **(B2)**.
+
+In the bundle:
+
+  - **(B1)** will have the custom metadata from **(A1)**.
+  - **(B2)** will have the custom metadata supplied for **(B2)** at the time of bundle creation.

--- a/src/docs/platform/reference/cohorts.md
+++ b/src/docs/platform/reference/cohorts.md
@@ -2,48 +2,30 @@
 
 Cohorts are logical groupings of devices within a [product](/platform/reference/products.md) that enable group metrics and [releases](/platform/reference/releases.md) for sub-sections of your fleet.
 
-## Groups
+## Logical groupings
 
-The first step of using cohorts is creating them. We recommend considering if you would want to target different groups with different release cadences or release content, or if you want to collect and analyze metrics for distinct groups. Those groups may be candidates to specify cohorts for.
-
-The following are common organizational themes:
+You may structure your cohorts as you wish, but the following are common approaches:
 
 - **Environments:** Organize devices into development, staging, and production cohorts.
 - **Release Channels:** Organize devices into nightly, canary, and stable cohorts.
 - **Operational Segments:** Organize devices into geographic, tenant-related, and other domain-specific cohorts.
 
-:::tip simple to complex
-Some use cases are satisfied with a single cohort, and some require an elaborate hierarchy. You can always adjust your cohorts and move devices between them.
+:::tip you can always change
+Some use cases are satisfied with a single cohort, and some require an elaborate hierarchy. You can always adjust your cohorts and move devices between them server-side later without requiring device-side changes.
+:::
+
+:::tip consider cadence, content, and metrics
+We recommend considering if you would want to target different devices with different release cadences or bundles, or if you want to collect and analyze metrics for distinct groups. Those groups may be candidates to specify cohorts for.
 :::
 
 ## Metrics
 
-One of the key benefits of using device cohorts is the ability to view and analyze metrics in the context of specific device groups. By comparing data across cohorts, you can gain valuable insights into how different subsets of your fleet are behaving and performing. Cohort-based metrics enable anomaly detection, release monitoring, and trend analysis.
+One of the key benefits of using cohorts is the ability to view and analyze metrics segmented by logical groups of devices. By comparing data across cohorts, you can gain valuable insights into how different subsets of your fleet are behaving and performing. Cohort-based metrics enable anomaly detection, release monitoring, and trend analysis.
 
-## Releases
+## Release channel
 
-Only devices within a cohort are compatible with using [releases](/platform/reference/releases.md) for updates.
+Cohorts are associated with zero to one [release channels](release-channels). Release channels are associated with zero to many cohorts. [Releases](releases) are associated with exactly one release channel.
 
-### Release graph
-
-Releases are created within cohorts to orchestrate the delivery of [bundles](/platform/reference/bundles.md) to devices. Within a cohort, releases form an [anti-arborescence](https://en.wikipedia.org/wiki/Arborescence_(graph_theory)) graph. In other words, releases may point to exactly one next release, a release may be pointed to by zero to many releases, and all releases eventually converge to a single [latest release](releases#latest-release).
-
-For example:
-
-```
-R4-------->R5---\
-                 \
-R1---\            |--->R6
-      |--->R2----/
-R3---/
-```
-
-`R6` above would be the latest release that all paths converge towards.
-
-While it is possible to end up with a release graph that looks like the above, it is recommended to keep as linear of a release graph as reasonably possible because it is easier to reason about and maintain.
-
-For example:
-
-```
-R1--->R2--->R3--->R4--->R5--->R6
-```
+:::tip release resolution requires cohorts
+Only devices within a cohort are able to perform [bundle resolution](bundle-distribution#bundle-resolution) via [release resolution](bundle-distribution#release-resolution-method).
+:::

--- a/src/docs/platform/reference/release-channels.md
+++ b/src/docs/platform/reference/release-channels.md
@@ -1,0 +1,71 @@
+# Release channels
+
+A release channel is a graph of releases associated with zero to many cohorts that specify the possible update paths devices within associated cohorts can traverse.
+
+:::tip bundle distribution
+For information about how release channels participate in resolving target bundles for devices, see the [bundle distribution](bundle-distribution) reference.
+:::
+
+## Graph details
+
+A release channel forms a [anti-arborescence](https://en.wikipedia.org/wiki/Arborescence_(graph_theory)) graph. In other words, releases may point to exactly one next release, a release may be pointed to by zero to many releases, and all releases eventually converge to a single release that points to no node.
+
+When reasoning about releases as nodes in such a graph, there are three categories of nodes:
+
+- **source nodes** - Nodes that no other nodes point to.
+- **intermediate nodes** - Nodes that are pointed to, and that point to other nodes.
+- **sink nodes** - Nodes that are pointed to, but point to no other nodes.
+
+:::tip latest release
+In conversation, the sink node is often referred to as the latest release.
+:::
+
+### Rules
+
+#### zero-to-one-sinks
+
+There can only ever be at most a single latest release at any given time. Or in graph terms, an anti-arborescence graph is either empty, or has at most a single sink node.
+
+#### only-sinks-constrain-availability
+
+The latest release of a graph is special in that it is the only release within a graph that is allowed to constrain its [availability](releases#availability).
+
+:::tip latest release creation pre-requisites
+This rule has the side effect of requiring the current latest release, should it exist, to have its availability unconstrained before a new latest release can be created.
+:::
+
+#### unconstrained-sink-before-new-sink
+
+You cannot create a new latest release while the current latest release has constrained availability.
+
+### Example
+
+Consider the following release channel:
+
+#### Figure 1
+
+```
+R4-------->R5---\
+                 \
+R1---\            |--->R6
+      |--->R2----/
+R3---/
+```
+
+- **source nodes** - `R4`, `R1`, and `R3`.
+- **intermediate nodes** - `R5` and `R2`.
+- **sink nodes** - `R6`.
+
+Or a more linear variation:
+
+#### Figure 2
+
+```
+R1--->R2--->R3--->R4--->R5--->R6
+```
+
+- **source nodes** - `R1`.
+- **intermediate nodes** - `R2-5`.
+- **sink nodes** - `R6`.
+
+In both [figure 1](#figure-1) and [figure 2](#figure-2) the latest release is the sink node `R6`.

--- a/src/docs/platform/reference/releases.md
+++ b/src/docs/platform/reference/releases.md
@@ -1,32 +1,62 @@
 # Releases
 
-Releases allow you to distribute [bundles](/platform/reference/bundles.md) to [cohorts](/platform/reference/cohorts.md). Each release is associated with exactly one cohort. Within a cohort, releases form a [graph](/platform/reference/cohorts.md#release-graph).
+Releases allow you to distribute [bundles](/platform/reference/bundles.md) to [cohorts](/platform/reference/cohorts.md) with support for versioning, ordering, required and disabled releases, and availability.
 
-## Latest release
+Each release is associated with exactly one cohort, but each cohort can have zero to many releases. Within a cohort, releases form a [release channel](release-channels). Each release is associated with exactly one bundle, but each bundle can be associated with zero to many releases and [bundle overrides](bundle-overrides).
 
-The latest release in a graph is the one whose `next_release_prn` is `null`. A graph only ever has at most one latest release at any given time. The latest release of a graph is special in that it is the only release within a graph that is allowed to limit its [rollout](#rollout) via scheduling and phasing.
+## Versioning
 
-:::info
+Releases support optionally specifying a SemVer version and a SemVer version requirement. These fields are useful for your own informational purposes, but also impact dynamic [ordering](#ordering) during [bundle resolution](bundle-distribution#bundle-resolution) via [release version resolution](bundle-distribution#release-resolution-method).
 
-You cannot create a new latest release while the current latest release is [scheduled](#scheduling) or [phased](#phasing).
-
+:::tip release version resolution
+If you **ever** wish to rely on dynamic ordering, it is strongly recommended to **always** specify version and version requirements on releases. Only releases that specify both fields are considered when performing [bundle resolution](bundle-distribution#bundle-resolution) via [release version resolution](bundle-distribution#release-resolution-method).
 :::
 
-## Rollout
+## Ordering
 
-A graph's latest release can schedule or limit its availability in pursuit of more precisely or gradually rolling out a bundle.
+Releases support static and dynamic ordering:
+
+  - **static** - Releases have a next release field that specifies an explicit path to be walked through a [release channel](release-channels) during [bundle resolution](bundle-distribution#bundle-resolution) via [release PRN resolution](bundle-distribution#release-resolution-method).
+  - **dynamic** - Releases have version and version requirement fields that specify an implicit path to be walked through a [release channel](release-channels) during [bundle resolution](bundle-distribution#bundle-resolution) via [release version resolution](bundle-distribution#release-resolution-method).
+
+For a detailed specification of how the [release channel](release-channels) is walked, see [bundle resolution](bundle-distribution#bundle-resolution).
+
+
+## Required and disabled
+
+Releases may be required or disabled to impact how they are treated during [bundle resolution](bundle-distribution#bundle-resolution):
+
+  - **required** - A required release cannot be skipped.
+  - **disabled** - A disabled release cannot have its bundle selected during [bundle resolution](bundle-distribution#bundle-resolution), but can be skipped so long as it is not required.
+
+## Availability
+
+The latest release in a release channel can optionally constrain its availability via schedling and phasing in pursuit of more precisely and gradually rolling out a bundle.
+
+With respect to availability evaluations:
+
+  - A release that is scheduled for the future is considered scheduled.
+    - A releases ceases to be scheduled once its schedule date has passed.
+  - A release that whose phase mode is not numeric or whose phase value is not 100% is considered phased.
+    - A release ceases to be phased once its phase mode is numeric and its phase value is 100%.
+  - A scheduled or phased release is considered to have its availability constrained.
+
+:::tip availability + release channels
+For details about how release availability can impact your ability to create new latest releases, see the [only-sinks-constrain-availability](release-channels#only-sinks-constrain-availability) release channel rule.
+:::
 
 ### Scheduling
 
-The latest release in a graph can be scheduled to become available immediately, or a date in the future can be choosen. This allows you to stage a release ahead of time and have it become available automatically at a specific time.
-
-A release ceases to be scheduled once its schedule date has passed.
+The latest release in a graph can be scheduled immediately or at a future date.
 
 ### Phasing
 
-The latest release in a graph can be made available gradually by configuring its phase mode. This can be used to limit how many devices are allowed to take the release either by tags or numerically.
+The latest release in a graph can be made available gradually by configuring its phase mode, this can be used to limit how many devices are allowed to take the release.
 
-A release ceases to be phased once its phase mode is numeric and its phase value is 100%.
+There are two supported phase modes that are mutually exclusive but can be updated between:
+
+  1. tags
+  2. numeric
 
 #### Tags
 
@@ -39,61 +69,6 @@ Limit the amount of devices that are able to update to the latest release by con
 - When a decimal in `[0.0, 1.0]`, it is treated as a percent, e.g., to allow 20% of the cohort to update, you would specifiy 0.2.
 - When an integer `>= 2`, it is treated as an absolute device count, e.g., to allow 40 of the cohort's devices to update, you would specifiy 40.
 
-## Release resolution
+## Distribution
 
-When a device executes a Device API [get-update](/device-api#devices/operation/get-update) request, Peridio performs release resolution. Release resolution is the process of determing if there is another release, referred to as the target release, the device can update to. To make this determination, Peridio must have some idea of determining where your device currently fits into it's cohort's release graph, since where a device currently is will determine where it needs to go.
-
-### Graph traversal
-
-In order for a release in the graph to be relevant to you, it must be between your current release, and the latest release.
-
-```
-R0-------->R1---\
-                 \
-R2---\            |--->R5
-      |--->R4----/
-R3---/
-```
-
-For example, if your current release was R0, then R1 is available with respect to graph traversal, but R2 is not.
-
-### Resolution
-
-Peridio must determine the device's current position in its cohort's release graph. Peridio will first attempt to determine this via [static resolution](#static-resolution), but can optionally fallback to [dynamic resolution](#dynamic-resolution).
-
-#### Static resolution
-
-Static resolution uses the `peridio-release-prn` header to supply its current release's PRN. If it successfully identifies a release in the device's cohort, then the current release is known. If the current release has a next release, then resolution continues with its next release. If not, then resolution falls back to dynamic resolution if possible. If not, then resolution completes with no target release.
-
-#### Dynamic resolution
-
-Dynamic resolution uses the `peridio-release-version` header to supply a [SemVer](https://semver.org/) version that is representative of the device's current release so that release version requirements can be leveraged to dynamically enter the release graph. If the cohort contains releases with a `version` and `version_requirement` specified, where the header supplied version satisfies the version requirements, then of those releases the one with the lowest version is considered the next release and resolution continues.
-
-Another variation of dynamic resolution uses the `peridio-bundle-prn` header, which supplies a bundle's PRN. This is relevant when using [bundle overrides](#bundle-overrides). When a device takes a bundle override, there will be no release or version to report back to Peridio. If this header successfully identifies a bundle, we attempt to identify the most appropriate corresponding release, then enter the release graph. When multiple releases in the device's cohort use the same bundle, we will try to select the release with the lowest [SemVer](https://semver.org/) version. As release versions are not required, release options for a bundle may or may not have versions. In the case that some matching releases have versions, and some do not, releases without a version will be discarded and version ranking will proceed. If none of the matching releases have a version, the earliest-created release will be selected.
-
-:::info prefer static resolution
-
-Static resolution should be used whenever possible as it is easier to reason about and more efficent to perform than dynamic resolution. However, when required, dynamic resolution can be used in situations where your device does not or can not know the PRN of its current release, yet it still wishes to deterministically update according to its cohort's release graph. For example, this can be useful when moving devices across cohorts.
-
-:::
-
-#### Bundle overrides
-
-An active bundle override may exist for a device. In this case, all resolution is skipped, and the configured bundle override's bundle will be returned. A bundle override is applicable when the time of resolution falls within the override's configured start and end times. In cases where multiple bundle overrides may apply, the most-recently starting override will be selected.
-
-
-#### Skip unrequired releases
-
-If static or dynamic resolution identify a next release we enter into a cycle where we attempt to skip as many releases in the graph as possible, only stopping if we encounter a required release or the latest release. If we encounter a required release, then resolution completes with it as the target release. If we encounter the latest release, then the release we just walked that points to it is considered the candidate release and we [evaluate the rollout](#rollout) of the latest release to determine if we can update to it or not right now. If we can, then resolution completes with the latest release as the target release. If not, then resolutions completes with the candidate release as the target release.
-
-### Activity diagram
-
-Below is a diagram that specifies how release resolution works in depth.
-
-:::tip the bigger picture
-
-To best expand the image, right click it and "Open Image in New Tab". From there you can more easily pan and zoom.
-
-:::
-
-<img src="/img/release-resolution.png" width="auto" />
+Releases, like [bundle overrides](bundle-overrides), are a method of bundle resolution detailed in the [bundle distribution](bundle-distribution) reference.

--- a/src/openapi/peridio-device-openapi.yaml
+++ b/src/openapi/peridio-device-openapi.yaml
@@ -10,13 +10,17 @@ info:
 
     # Global Headers
 
-    The following headers may be supplied when requesting any endpoint.
+    The following headers may be supplied when requesting any route.
+
+    For critical context about how Peridio Cloud will interpret these headers, refer to the [device integration](/platform/reference/bundle-distribution#device-integration) section of the [bundle distribution](/platform/reference/bundle-distribution) reference.
+
+    For context regarding deprecated headers, see [deployment eligibility](/platform/reference/deployments#deployment-eligibility).
 
     |key|value|description|
     |-|-|-|
-    |peridio-release-prn|A release PRN.|See [release resolution](/platform/reference/releases#release-resolution). Informs Peridio of what release is currently active on the device. The preference should always be to supply this header with a valid value. If you supply this header, you should not supply the `peridio-release-version` header.|
-    |peridio-release-version|A release version.|See [release resolution](/platform/reference/releases#release-resolution). This header is only used in exceptional cases when you don't have a PRN to supply via `peridio-release-prn`. In that case, you may supply this header and you should not supply the `peridio-release-prn` header.|
-    |peridio-bundle-prn|A bundle PRN.|See [release resolution](/platform/reference/releases#release-resolution). Informs Peridio of what bundle is currently active on the device. This header is used when the device has a bundle override, and therefore no release. If you supply this header, you should not supply the `peridio-release-prn` or `peridio-release-version` header.|
+    |peridio-release-prn|A release PRN.|Informs Peridio of what release is currently active on the device.|
+    |peridio-bundle-prn|A bundle PRN.|Informs Peridio of what bundle is currently active on the device.|
+    |peridio-release-version|A release version.|Informs Peridio of what release version is representative of the device's state.|
     |x-peridio-architecture|A firmware architecture.|Deprecated. See [deployment eligibility](/platform/reference/deployments#deployment-eligibility). The architecture of the device's currently active firmware. When supplying any `x-peridio` header, you should supply all `x-peridio` headers.|
     |x-peridio-platform|A firmware platform.|Deprecated. See [deployment eligibility](/platform/reference/deployments#deployment-eligibility). The platform of the device's currently active firmware. When supplying any `x-peridio` header, you should supply all `x-peridio` headers.|
     |x-peridio-product|A firmware product.|Deprecated. See [deployment eligibility](/platform/reference/deployments#deployment-eligibility). The product of the device's currently active firmware. When supplying any `x-peridio` header, you should supply all `x-peridio` headers.|
@@ -205,7 +209,7 @@ paths:
       operationId: get-update
       summary: get update
       description: |
-        Returns information regarding whether an update is available via a [release](/admin-api#releases).
+        Returns information regarding whether an update is available via a [release](/platform/reference/releases) or [bundle override](/platform/reference/bundle-overrides).
 
         ### Expandable
 
@@ -216,7 +220,7 @@ paths:
         - in: header
           name: peridio-release-prn
           schema:
-            description: See [global headers](#global-headers).
+            description: See [global headers](#section/Global-Headers).
             examples:
               [
                 prn:1:a1ed0c4e-f222-4bb3-89dc-48320018875d:release:e4bf3021-b8d7-42d5-a1bd-52121427ebd0,
@@ -224,9 +228,20 @@ paths:
             $ref: "peridio-admin-openapi.yaml#/components/schemas/prn"
           required: false
         - in: header
+          name: peridio-bundle-prn
+          schema:
+            description: See [global headers](#section/Global-Headers).
+            examples:
+              [
+                prn:1:a1ed0c4e-f222-4bb3-89dc-48320018875d:bundle:ddd32c59-fc35-4202-a520-a4eddaa11fb3,
+              ]
+            $ref: "peridio-admin-openapi.yaml#/components/schemas/prn"
+          required: false
+        - in: header
           name: peridio-release-version
           schema:
-            description: See [global headers](#global-headers).
+            description: See [global headers](#section/Global-Headers).
+            examples: [1.0.0]
             $ref: "peridio-admin-openapi.yaml#/components/schemas/release-version"
           required: false
         - name: expand

--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -12,7 +12,7 @@ export default {
         'platform/reference/overview',
         {
           type: 'category',
-          label: 'Account Management',
+          label: 'Account management',
           items: [
             'platform/reference/organizations',
             'platform/reference/peridio-resource-names',
@@ -21,7 +21,7 @@ export default {
         },
         {
           type: 'category',
-          label: 'Binary Management',
+          label: 'Binary management',
           items: [
             {
               type: 'doc',
@@ -49,16 +49,11 @@ export default {
               id: 'platform/reference/binary-signatures',
             },
             'platform/reference/signing-keys',
-            {
-              type: 'doc',
-              label: 'Firmware',
-              id: 'platform/reference/firmware',
-            },
           ],
         },
         {
           type: 'category',
-          label: 'Device Management',
+          label: 'Device management',
           items: [
             {
               type: 'doc',
@@ -82,12 +77,12 @@ export default {
         },
         {
           type: 'category',
-          label: 'Integration Management',
+          label: 'Integration management',
           items: ['platform/reference/webhooks'],
         },
         {
           type: 'category',
-          label: 'Release Mangement',
+          label: 'Bundle mangement',
           items: [
             {
               type: 'doc',
@@ -96,21 +91,46 @@ export default {
             },
             {
               type: 'doc',
-              label: 'Deployments',
-              id: 'platform/reference/deployments',
+              label: 'Releases',
+              id: 'platform/reference/releases',
             },
             {
               type: 'doc',
-              label: 'Releases',
-              id: 'platform/reference/releases',
+              label: 'Release channels',
+              id: 'platform/reference/release-channels',
+            },
+            {
+              type: 'doc',
+              label: 'Bundle overrides',
+              id: 'platform/reference/bundle-overrides',
+            },
+            {
+              type: 'doc',
+              label: 'Bundle distribution',
+              id: 'platform/reference/bundle-distribution',
             },
           ],
         },
         {
           type: 'category',
-          label: 'Remote Access',
+          label: 'Remote access',
           items: ['platform/reference/tunnels'],
-          customProps: { labs: true },
+        },
+        {
+          type: 'category',
+          label: 'Deprecated',
+          items: [
+            {
+              type: 'doc',
+              label: 'Firmware',
+              id: 'platform/reference/firmware',
+            },
+            {
+              type: 'doc',
+              label: 'Deployments',
+              id: 'platform/reference/deployments',
+            },
+          ],
         },
       ],
     },
@@ -122,7 +142,7 @@ export default {
       items: [
         {
           type: 'category',
-          label: 'Binary Management',
+          label: 'Binary management',
           items: [
             'platform/guides/introduction-to-binary-management',
             'platform/guides/multipart-uploads-with-binary-parts',
@@ -132,12 +152,11 @@ export default {
             'platform/guides/creating-binaries',
             'platform/guides/creating-binary-parts',
             'platform/guides/creating-binary-signatures',
-            'platform/guides/creating-firmware',
           ],
         },
         {
           type: 'category',
-          label: 'Device Management',
+          label: 'Device management',
           items: [
             'platform/guides/creating-ca-certificates',
             'platform/guides/creating-devices',
@@ -148,22 +167,28 @@ export default {
         },
         {
           type: 'category',
-          label: 'Release Management',
+          label: 'Bundle management',
           items: [
-            'platform/guides/introduction-to-release-management',
+            'platform/guides/introduction-to-bundle-management',
             'platform/guides/creating-bundles',
-            'platform/guides/creating-deployments',
             'platform/guides/creating-releases',
           ],
         },
         {
           type: 'category',
-          label: 'Remote Access',
+          label: 'Remote access',
           items: [
             'platform/guides/introduction-to-remote-access',
             'platform/guides/creating-tunnels',
           ],
-          customProps: { labs: true },
+        },
+        {
+          type: 'category',
+          label: 'Deprecated',
+          items: [
+            'platform/guides/creating-firmware',
+            'platform/guides/creating-deployments',
+          ],
         },
       ],
     },


### PR DESCRIPTION
- Generally shift language to consider bundle management/distribution to be the higher level topic than releases; releases are a means of performing bundle distribution alongside bundle overrides.
- Add a bundle distribution reference.
- Add a bundle overrides reference.
- Update the bundles reference to support the wider commit's changes and add a section on custom metadata.
- Update cohorts reference to begin introducing release channel language.
- Add a release channels reference.
- Update the releases reference to support the wider commit's changes.
- Update the device API spec to clarify header documentation and link to the relevant reference page.
- Rework the sidebar slightly for clarity and consistency.
- Move firmware and deployments references and guides into deprecated sections.