### PR TITLE
[AHAPI] fix omission in api spec

### DIFF
--- a/src/openapi/peridio-admin-openapi.yaml
+++ b/src/openapi/peridio-admin-openapi.yaml
@@ -320,7 +320,7 @@ paths:
         |-|-|-|-|
         |`description`||`:`, `~`|string|
         |`inserted_at`||`:`, `>`, `>=`, `<`, `<=`|date-time|
-        |`name`||`:`, `~`|string|
+        |`name`||`:`, `~`, `-`|string|
         |`organization_prn`|X|`:`|prn|
         |`prn`||`:`|string|
         |`updated_at`||`:`, `>`, `>=`, `<`, `<=` |date-time|


### PR DESCRIPTION
Specify that list-artifacts search param can filter name with a case-insensitive substring.