### PR TITLE
Update mega navigation menu structure

### DIFF
--- a/src/src/components/MegaMenuNavbar/MobileMenu.js
+++ b/src/src/components/MegaMenuNavbar/MobileMenu.js
@@ -11,48 +11,24 @@ const MobileMenu = ({ isOpen, onClose }) => {
 
   const menuSections = [
     {
-      title: 'Quickstart',
+      title: 'Featured Hardware',
       items: [
-        { label: 'EVK Demo', to: '/evk' },
-        { label: 'Platform Getting Started', to: '/platform/getting-started' },
+        { label: 'NXP IMX8MP', to: '/solutions/nxp/imx8mp' },
+        { label: 'NXP FRDM 93', to: '/solutions/nxp/frdm-93' },
+        { label: 'Raspberry Pi', to: '/solutions/raspberry-pi/raspberry-pi' },
+        { label: 'NVIDIA Jetson', to: '/solutions/nvidia/jetson-orin-nano' },
+        { label: 'Advantech ICAM 540', to: '/solutions/icam540' },
+        { label: 'Onlogic FR201', to: '/solutions/onlogic/fr201' },
+        { label: 'Seed Reterminal', to: '/solutions/seed/reterminal' },
       ],
     },
     {
-      title: 'Platform',
+      title: 'Tools',
       items: [
-        { label: 'Overview', to: '/platform/reference/overview' },
-        { label: 'Creating Releases', to: '/platform/guides/creating-releases' },
-        { label: 'Cloud-Delegated Updates', to: '/platform/guides/cloud-delegated-updates' },
-        { label: 'Fleet View', to: '/platform/reference/fleet-view' },
         { label: 'CLI', to: '/cli' },
-        { label: 'Admin API', to: '/admin-api' },
         { label: 'Device API', to: '/device-api' },
-      ],
-    },
-    {
-      title: 'Integration',
-      items: [
-        { label: 'Linux Overview', to: '/integration/linux/overview' },
-        { label: 'Android Overview', to: '/integration/android/overview' },
-        { label: 'Buildroot', to: '/integration/linux/build-tools/buildroot' },
-        { label: 'Yocto', to: '/integration/linux/build-tools/yocto' },
-      ],
-    },
-    {
-      title: 'Build & Ship',
-      items: [
-        { label: 'Creating Artifacts', to: '/platform/guides/creating-artifacts' },
-        { label: 'Creating Binaries', to: '/platform/guides/creating-binaries' },
-        { label: 'Creating Bundles', to: '/platform/guides/creating-bundles' },
-        { label: 'CA Certificates', to: '/platform/guides/creating-ca-certificates' },
-      ],
-    },
-    {
-      title: 'Operate',
-      items: [
-        { label: 'Creating Devices', to: '/platform/guides/creating-devices' },
-        { label: 'Creating Deployments', to: '/platform/guides/creating-deployments' },
-        { label: 'Creating Tunnels', to: '/platform/guides/creating-tunnels' },
+        { label: 'Admin API', to: '/admin-api' },
+        { label: 'Peridio Agent', to: '/dev-center/agents/peridio-agent' },
       ],
     },
   ]
@@ -68,6 +44,15 @@ const MobileMenu = ({ isOpen, onClose }) => {
           </button>
         </div>
         <div className="mobile-menu-content">
+          <div className="mobile-menu-section">
+            <Link
+              to="/dev-center"
+              className="mobile-menu-section-title"
+              onClick={onClose}
+            >
+              Get Started
+            </Link>
+          </div>
           {menuSections.map((section, index) => (
             <div key={index} className="mobile-menu-section">
               <button className="mobile-menu-section-title" onClick={() => toggleSection(index)}>
@@ -106,7 +91,7 @@ const MobileMenu = ({ isOpen, onClose }) => {
               rel="noopener noreferrer"
               onClick={onClose}
             >
-              Log in to Web Console
+              Web Console
             </Link>
           </div>
         </div>

--- a/src/src/components/MegaMenuNavbar/index.js
+++ b/src/src/components/MegaMenuNavbar/index.js
@@ -35,215 +35,44 @@ const MegaMenuNavbar = () => {
   }, [])
 
   const megaMenuItems = {
-    quickstart: {
-      label: 'Quickstart',
-      sections: [
-        {
-          title: 'Get Started',
-          items: [
-            { label: 'EVK Demo', to: '/evk' },
-            { label: 'Platform Getting Started', to: '/platform/getting-started' },
-          ],
-        },
-      ],
-    },
-    'dev-center': {
-      label: 'Dev Center',
-      sections: [
-        {
-          title: 'Developer Resources',
-          items: [
-            { label: 'Overview', to: '/dev-center' },
-            { label: 'Getting Started', to: '/dev-center/getting-started/raspberry-pi' },
-            { label: 'Avocado Linux', to: '/dev-center/avocado-linux/introduction' },
-            { label: 'Hardware Support', to: '/dev-center/hardware/raspberry-pi/overview' },
-            { label: 'Peridio Core', to: '/dev-center/peridio-core/introduction' },
-          ],
-        },
-      ],
-    },
-    solutions: {
-      label: 'Hardware',
+    hardware: {
+      label: 'Featured Hardware',
       sections: [
         {
           title: 'EVKs',
           items: [
-            { label: 'NXP i.MX 8M Plus', to: '/solutions/nxp/imx8mp' },
-            { label: 'NVIDIA Jetson Orin Nano', to: '/solutions/nvidia/jetson-orin-nano' },
-            { label: 'Qualcomm Rubik Pi', to: '/solutions/qualcomm/rubik-pi' },
-            { label: 'Qualcomm IQ-9', to: '/solutions/qualcomm/iq-9' },
+            { label: 'NXP IMX8MP', to: '/solutions/nxp/imx8mp' },
+            { label: 'NXP FRDM 93', to: '/solutions/nxp/frdm-93' },
             { label: 'Raspberry Pi', to: '/solutions/raspberry-pi/raspberry-pi' },
-            { label: 'ST Micro STM32MP257F-DK', to: '/solutions/stmicro/stm32mp157d-dk' },
+            { label: 'NVIDIA Jetson', to: '/solutions/nvidia/jetson-orin-nano' },
           ],
         },
         {
           title: 'Production Ready',
-          items: [{ label: 'icam540', to: '/solutions/icam540' }],
-        },
-      ],
-    },
-    platform: {
-      label: 'Platform',
-      sections: [
-        {
-          title: 'Guides',
           items: [
-            { label: 'Creating Releases', to: '/platform/guides/creating-releases' },
-            { label: 'Cloud-Delegated Updates', to: '/platform/guides/cloud-delegated-updates' },
-            {
-              label: 'Remote Access & Tunnels',
-              to: '/platform/guides/introduction-to-remote-access',
-            },
-            {
-              label: 'Binary Management',
-              to: '/platform/guides/introduction-to-binary-management',
-            },
-            {
-              label: 'Bundle Management',
-              to: '/platform/guides/introduction-to-bundle-management',
-            },
-          ],
-        },
-        {
-          title: 'Reference',
-          items: [
-            { label: 'Overview', to: '/platform/reference/overview' },
-            { label: 'Devices', to: '/platform/reference/devices' },
-            { label: 'Artifacts', to: '/platform/reference/artifacts' },
-            { label: 'Bundles', to: '/platform/reference/bundles' },
-            { label: 'Cohorts', to: '/platform/reference/cohorts' },
-            { label: 'Fleet View', to: '/platform/reference/fleet-view' },
-          ],
-        },
-        {
-          title: 'Tools',
-          items: [
-            { label: 'CLI', to: '/cli' },
-            { label: 'Admin API', to: '/admin-api' },
-            { label: 'Device API', to: '/device-api' },
+            { label: 'Advantech ICAM 540', to: '/solutions/icam540' },
+            { label: 'Onlogic FR201', to: '/solutions/onlogic/fr201' },
+            { label: 'Seed Reterminal', to: '/solutions/seed/reterminal' },
           ],
         },
       ],
+      twoColumn: true,
     },
-    integration: {
-      label: 'Integration',
-      sections: [
-        {
-          title: 'Linux',
-          items: [
-            { label: 'Overview', to: '/integration/linux/overview' },
-            { label: 'Buildroot', to: '/integration/linux/build-tools/buildroot' },
-            { label: 'Yocto', to: '/integration/linux/build-tools/yocto' },
-            { label: 'peridiod Config', to: '/integration/linux/peridiod/configuration' },
-            { label: 'peridiod Updates', to: '/integration/linux/peridiod/updates' },
-          ],
-        },
-        {
-          title: 'Reference Designs',
-          items: [
-            {
-              label: 'i.MX6ULL EVK',
-              to: '/integration/linux/reference-designs/imx6ullevk/overview',
-            },
-            {
-              label: 'Khadas VIM3',
-              to: '/integration/linux/reference-designs/khadas-vim3/overview',
-            },
-            {
-              label: 'Raspberry Pi 4',
-              to: '/integration/linux/reference-designs/raspberrypi4/overview',
-            },
-            {
-              label: 'Raspberry Pi 5',
-              to: '/integration/linux/reference-designs/raspberrypi5/overview',
-            },
-            { label: 'QEMU ARM64', to: '/integration/linux/reference-designs/qemu-arm64/overview' },
-          ],
-        },
-        {
-          title: 'Android',
-          items: [
-            { label: 'Overview', to: '/integration/android/overview' },
-            {
-              label: 'Direct API Integration',
-              to: '/integration/android/reference-designs/direct-api-integration',
-            },
-          ],
-        },
-      ],
-    },
-    build: {
-      label: 'Build & Ship',
-      sections: [
-        {
-          title: 'Artifacts & Binaries',
-          items: [
-            { label: 'Creating Artifacts', to: '/platform/guides/creating-artifacts' },
-            {
-              label: 'Creating Artifact Versions',
-              to: '/platform/guides/creating-artifact-versions',
-            },
-            { label: 'Creating Binaries', to: '/platform/guides/creating-binaries' },
-            { label: 'Creating Binary Parts', to: '/platform/guides/creating-binary-parts' },
-            {
-              label: 'Multipart Uploads',
-              to: '/platform/guides/multipart-uploads-with-binary-parts',
-            },
-          ],
-        },
-        {
-          title: 'Signing & Security',
-          items: [
-            { label: 'CA Certificates', to: '/platform/guides/creating-ca-certificates' },
-            {
-              label: 'X.509 via OpenSSL',
-              to: '/platform/guides/creating-x509-certificates-with-openssl',
-            },
-            {
-              label: 'X.509 via Peridio',
-              to: '/platform/guides/creating-x509-certificates-with-peridio',
-            },
-            { label: 'Signing Keys', to: '/platform/guides/creating-signing-keys' },
-          ],
-        },
-        {
-          title: 'Advanced',
-          items: [
-            { label: 'Custom Binary Backends', to: '/platform/guides/custom-binary-backends' },
-            { label: 'Creating Bundles', to: '/platform/guides/creating-bundles' },
-          ],
-        },
-      ],
-    },
-    operate: {
-      label: 'Operate',
-      sections: [
-        {
-          title: 'Device Management',
-          items: [
-            { label: 'Creating Devices', to: '/platform/guides/creating-devices' },
-            { label: 'Creating Deployments', to: '/platform/guides/creating-deployments' },
-            { label: 'Fleet View', to: '/platform/reference/fleet-view' },
-            { label: 'Device Certificates', to: '/platform/reference/device-certificates' },
-          ],
-        },
-        {
-          title: 'Release Management',
-          items: [
-            { label: 'Release Channels', to: '/platform/reference/release-channels' },
-            { label: 'Cohorts', to: '/platform/reference/cohorts' },
-            { label: 'Bundle Overrides', to: '/platform/reference/bundle-overrides' },
-          ],
-        },
-        {
-          title: 'Remote Access',
-          items: [
-            { label: 'Creating Tunnels', to: '/platform/guides/creating-tunnels' },
-            { label: 'Tunnels Reference', to: '/platform/reference/tunnels' },
-          ],
-        },
-      ],
-    },
+  }
+
+  const toolsMenu = {
+    label: 'Tools',
+    sections: [
+      {
+        title: '',
+        items: [
+          { label: 'CLI', to: '/cli' },
+          { label: 'Device API', to: '/device-api' },
+          { label: 'Admin API', to: '/admin-api' },
+          { label: 'Peridio Agent', to: '/dev-center/agents/peridio-agent' },
+        ],
+      },
+    ],
   }
 
   return (
@@ -254,6 +83,9 @@ const MegaMenuNavbar = () => {
             <img src={`/${navbar.logo.src}`} alt={navbar.logo.alt} className="navbar__logo" />
           </Link>
           <div className="mega-menu-container">
+            <Link to="/dev-center" className="navbar__item navbar__link">
+              Get Started
+            </Link>
             {Object.entries(megaMenuItems).map(([key, menu]) => (
               <div
                 key={key}
@@ -270,7 +102,7 @@ const MegaMenuNavbar = () => {
 
                 {activeMenu === key && (
                   <div className="mega-menu-dropdown">
-                    <div className="mega-menu-content">
+                    <div className={`mega-menu-content ${menu.twoColumn ? 'two-column' : ''}`}>
                       {menu.sections.map((section, sectionIndex) => (
                         <div key={sectionIndex} className="mega-menu-section">
                           <Heading as="h4" className="mega-menu-section-title">
@@ -305,6 +137,44 @@ const MegaMenuNavbar = () => {
         </div>
 
         <div className="navbar__items navbar__items--right">
+          <div
+            className="mega-menu-item"
+            onMouseEnter={() => handleMouseEnter('tools')}
+            onMouseLeave={handleMouseLeave}
+          >
+            <span className="mega-menu-trigger">
+              {toolsMenu.label}
+              <svg width="12" height="8" viewBox="0 0 12 8" className="mega-menu-arrow">
+                <path d="M1 1l5 5 5-5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+              </svg>
+            </span>
+
+            {activeMenu === 'tools' && (
+              <div className="mega-menu-dropdown">
+                <div className="mega-menu-content">
+                  {toolsMenu.sections.map((section, sectionIndex) => (
+                    <div key={sectionIndex} className="mega-menu-section">
+                      {section.title && (
+                        <Heading as="h4" className="mega-menu-section-title">
+                          {section.title}
+                        </Heading>
+                      )}
+                      <ul className="mega-menu-links">
+                        {section.items.map((item, itemIndex) => (
+                          <li key={itemIndex}>
+                            <Link to={item.to} className="mega-menu-link">
+                              {item.label}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
           <Link
             to="https://console.peridio.com"
             className="navbar__item navbar__link"

--- a/src/src/components/MegaMenuNavbar/styles.css
+++ b/src/src/components/MegaMenuNavbar/styles.css
@@ -5,9 +5,50 @@
   margin-left: 2rem;
 }
 
+.mega-menu-container .navbar__link {
+  padding: 0.5rem 0;
+  margin-right: 1rem;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--ifm-navbar-link-color);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.mega-menu-container .navbar__link:hover {
+  color: var(--ifm-navbar-link-hover-color);
+  text-decoration: none;
+}
+
 .mega-menu-item {
   position: relative;
   margin-right: 1rem;
+}
+
+.navbar__items--right .mega-menu-item {
+  margin-right: 1rem;
+  margin-left: 0;
+}
+
+.navbar__items--right .mega-menu-dropdown {
+  right: 0;
+  left: auto;
+  min-width: 200px;
+}
+
+.navbar__items--right .navbar__link {
+  padding: 0.5rem 0;
+  margin-left: 1rem;
+  font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--ifm-navbar-link-color);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.navbar__items--right .navbar__link:hover {
+  color: var(--ifm-navbar-link-hover-color);
+  text-decoration: none;
 }
 
 .mega-menu-trigger {
@@ -53,6 +94,11 @@
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 2rem;
   padding: 2rem;
+}
+
+.mega-menu-content.two-column {
+  grid-template-columns: repeat(2, 1fr);
+  gap: 3rem;
 }
 
 .mega-menu-section {

--- a/src/src/theme/Navbar/index.js
+++ b/src/src/theme/Navbar/index.js
@@ -6,10 +6,11 @@ import SimpleNavbar from '../../components/SimpleNavbar'
 export default function Navbar(props) {
   const location = useLocation()
 
-  // Use MegaMenuNavbar only for dev-center pages
+  // Use MegaMenuNavbar for dev-center and solutions pages
   const isDevCenter = location.pathname.startsWith('/dev-center')
+  const isSolutions = location.pathname.startsWith('/solutions')
 
-  if (isDevCenter) {
+  if (isDevCenter || isSolutions) {
     return <MegaMenuNavbar {...props} />
   }
 


### PR DESCRIPTION
## Summary
- Simplified navigation structure to focus on Get Started, Featured Hardware, and Tools
- Moved Tools dropdown to the right side next to Web Console for better UX
- Enabled mega nav for solutions (Featured Hardware) pages

## Changes
- Updated MegaMenuNavbar to show only Get Started, Featured Hardware, and Tools
- Added two-column layout for Featured Hardware dropdown (EVKs and Production Ready)
- Moved Tools to right side of navbar next to Web Console
- Ensured consistent font sizing (font-weight: 500, font-size: 0.875rem) across all menu items
- Updated mobile menu to match the new desktop navigation structure
- Extended mega nav usage to solutions pages via theme Navbar component
- Fixed Peridio Agent link to point to dev-center page

## Test plan
- [x] Run `npm run lint` - no errors
- [x] Run `npm run build` - builds successfully
- [x] Navigate to dev-center pages - verify mega nav appears
- [x] Navigate to solutions pages - verify mega nav appears
- [x] Test dropdown menus on desktop
- [ ] Test mobile menu on small screens
- [ ] Verify all navigation links work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)