### PR TITLE
feat: Update marketing pages and navigation

### DIFF
--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -286,7 +286,7 @@ export default {
   'dev-center': [
     {
       type: 'category',
-      label: '🚧 Getting Started',
+      label: 'Getting Started',
       link: {
         type: 'doc',
         id: 'dev-center/index',
@@ -297,17 +297,17 @@ export default {
         {
           type: 'doc',
           id: 'dev-center/getting-started/provision-device',
-          label: '🚧 Provision Device',
+          label: 'Provision Device',
         },
         {
           type: 'doc',
           id: 'dev-center/getting-started/program-device',
-          label: '🚧 Program Device',
+          label: 'Program Device',
         },
         {
           type: 'doc',
           id: 'dev-center/getting-started/first-ota-update',
-          label: '🚧 First OTA Update',
+          label: 'First OTA Update',
         },
       ],
     },
@@ -388,7 +388,7 @@ export default {
     },
     {
       type: 'category',
-      label: '🚧 Supported Hardware',
+      label: 'Supported Hardware',
       link: {
         type: 'doc',
         id: 'dev-center/hardware/supported-hardware',
@@ -407,43 +407,43 @@ export default {
             {
               type: 'doc',
               id: 'dev-center/hardware/production-ready/seeed-reterminal',
-              label: '🚧 Seeed reTerminal',
+              label: 'Seeed reTerminal',
             },
             {
               type: 'doc',
               id: 'dev-center/hardware/production-ready/icam540',
-              label: '🚧 iCam540',
+              label: 'iCam540',
             },
             {
               type: 'doc',
               id: 'dev-center/hardware/production-ready/onlogic-factor',
-              label: '🚧 OnLogic Factor 201/202',
+              label: 'OnLogic Factor 201/202',
             },
           ],
         },
         {
           type: 'doc',
           id: 'dev-center/hardware/nvidia/jetson-orin-nano-evk',
-          label: '🚧 NVIDIA Jetson Orin Nano EVK',
+          label: 'NVIDIA Jetson Orin Nano EVK',
         },
         {
           type: 'doc',
           id: 'dev-center/hardware/nxp/frdm-imx-93',
-          label: '🚧 NXP i.MX 93 FRDM SBC',
+          label: 'NXP i.MX 93 FRDM SBC',
         },
-        { type: 'doc', id: 'dev-center/hardware/nxp/imx8mp', label: '🚧 NXP i.MX 8MP EVK' },
+        { type: 'doc', id: 'dev-center/hardware/nxp/imx8mp', label: 'NXP i.MX 8MP EVK' },
         {
           type: 'doc',
           id: 'dev-center/hardware/raspberry-pi/compute-module-4',
-          label: '🚧 Raspberry Pi Compute Module 4',
+          label: 'Raspberry Pi Compute Module 4',
         },
-        { type: 'doc', id: 'dev-center/hardware/qemu', label: '🚧 QEMU (Virtual Machine)' },
+        { type: 'doc', id: 'dev-center/hardware/qemu', label: 'QEMU (Virtual Machine)' },
         { type: 'doc', id: 'dev-center/hardware/coming-soon', label: '🚀 Coming Soon' },
       ],
     },
     {
       type: 'category',
-      label: '🚧 Integration / Guides',
+      label: 'Integration / Guides',
       link: {
         type: 'doc',
         id: 'dev-center/integration/index',
@@ -515,7 +515,7 @@ export default {
     },
     {
       type: 'category',
-      label: '🚧 Policies',
+      label: 'Policies',
       link: {
         type: 'doc',
         id: 'dev-center/policies/index',

--- a/src/src/components/HardwareCarousel/index.js
+++ b/src/src/components/HardwareCarousel/index.js
@@ -14,6 +14,7 @@ const slides = [
     vendor: 'Raspberry Pi',
     target: 'Raspberry Pi 4 / 5',
     image: '/img/raspberry-pi.jpg',
+    link: '/solutions/raspberry-pi/raspberry-pi',
   },
   {
     vendor: 'NXP',
@@ -99,13 +100,13 @@ export default function HardwareCarousel() {
                 {slide.vendor}
               </Heading>
               <p className={styles.target}>{slide.target}</p>
-              {/* Links hidden for now
-                            <div className={styles.links}>
-                                <Link to={slide.link} className={styles.link}>Solution Overview</Link>
-                                <Link to="#" className={styles.link}>Data Sheet</Link>
-                                <Link to="#" className={styles.link}>Try It</Link>
-                            </div>
-                            */}
+              <div className={styles.links}>
+                {slide.link && (
+                  <Link to={slide.link} className={styles.link}>
+                    Solution Overview
+                  </Link>
+                )}
+              </div>
             </div>
           </div>
         ))}

--- a/src/src/components/MegaMenuNavbar/MobileMenu.js
+++ b/src/src/components/MegaMenuNavbar/MobileMenu.js
@@ -17,9 +17,9 @@ const MobileMenu = ({ isOpen, onClose }) => {
         { label: 'NXP FRDM 93', to: '/solutions/nxp/frdm-93' },
         { label: 'Raspberry Pi', to: '/solutions/raspberry-pi/raspberry-pi' },
         { label: 'NVIDIA Jetson', to: '/solutions/nvidia/jetson-orin-nano' },
-        { label: 'Advantech ICAM 540', to: '/solutions/icam540' },
-        { label: 'Onlogic FR201', to: '/solutions/onlogic/fr201' },
-        { label: 'Seed Reterminal', to: '/solutions/seed/reterminal' },
+        { label: 'Advantech ICAM 540', to: '/solutions/advantech/icam-540' },
+        { label: 'OnLogic FR201', to: '/solutions/onlogic' },
+        { label: 'Seeed reTerminal', to: '/solutions/seeed' },
       ],
     },
     {
@@ -45,13 +45,13 @@ const MobileMenu = ({ isOpen, onClose }) => {
         </div>
         <div className="mobile-menu-content">
           <div className="mobile-menu-section">
-            <Link
-              to="/dev-center"
+            <a
+              href="https://docs.peridio.com"
               className="mobile-menu-section-title"
               onClick={onClose}
             >
-              Get Started
-            </Link>
+              Developer Home
+            </a>
           </div>
           {menuSections.map((section, index) => (
             <div key={index} className="mobile-menu-section">

--- a/src/src/components/MegaMenuNavbar/index.js
+++ b/src/src/components/MegaMenuNavbar/index.js
@@ -50,9 +50,9 @@ const MegaMenuNavbar = () => {
         {
           title: 'Production Ready',
           items: [
-            { label: 'Advantech ICAM 540', to: '/solutions/icam540' },
-            { label: 'Onlogic FR201', to: '/solutions/onlogic/fr201' },
-            { label: 'Seed Reterminal', to: '/solutions/seed/reterminal' },
+            { label: 'Advantech ICAM 540', to: '/solutions/advantech/icam-540' },
+            { label: 'OnLogic FR201', to: '/solutions/onlogic' },
+            { label: 'Seeed reTerminal', to: '/solutions/seeed' },
           ],
         },
       ],
@@ -79,13 +79,13 @@ const MegaMenuNavbar = () => {
     <nav className="navbar navbar--fixed-top">
       <div className="navbar__inner">
         <div className="navbar__items">
-          <Link to="/" className="navbar__brand">
+          <a href="https://peridio.com" className="navbar__brand" target="_blank" rel="noopener noreferrer">
             <img src={`/${navbar.logo.src}`} alt={navbar.logo.alt} className="navbar__logo" />
-          </Link>
+          </a>
           <div className="mega-menu-container">
-            <Link to="/dev-center" className="navbar__item navbar__link">
-              Get Started
-            </Link>
+            <a href="https://docs.peridio.com" className="navbar__item navbar__link">
+              Developer Home
+            </a>
             {Object.entries(megaMenuItems).map(([key, menu]) => (
               <div
                 key={key}

--- a/src/src/pages/solutions/advantech/icam-540.js
+++ b/src/src/pages/solutions/advantech/icam-540.js
@@ -3,61 +3,61 @@ import Layout from '@theme/Layout'
 import Head from '@docusaurus/Head'
 import Link from '@docusaurus/Link'
 import Heading from '@theme/Heading'
-import styles from './jetson-orin-nano.module.css'
+import styles from './icam-540.module.css'
 import {
-  HiOutlineRocketLaunch as RocketLaunchIcon,
-  HiOutlineLockClosed as LockClosedIcon,
-  HiOutlineWifi as WifiIcon,
-  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
-  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineCamera as CameraIcon,
+  HiOutlineCpuChip as CpuChipIcon,
   HiOutlineShieldCheck as ShieldCheckIcon,
+  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineBuildingOffice2 as BuildingOfficeIcon,
+  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
   HiOutlineXMark as XMarkIcon,
   HiOutlineCheck as CheckIcon,
 } from 'react-icons/hi2'
 
-export default function JetsonOrinNanoSolution() {
+export default function ICAM540Solution() {
   return (
     <Layout>
       <Head>
-        <title>NVIDIA Jetson Orin Nano Production Linux | Day 1 Ready | Peridio</title>
+        <title>Advantech ICAM-540 Industrial AI Camera | Production Ready | Peridio</title>
         <meta
           name="description"
-          content="Production-ready NVIDIA Jetson Orin Nano deployment from day 1 with Peridio Fleet + Avocado OS. Enterprise Linux, secure OTA, and fleet management for industrial AI."
+          content="Deploy Advantech ICAM-540 industrial AI cameras with NVIDIA Jetson Xavier NX, IP67 protection, and enterprise fleet management. Production-ready computer vision."
         />
         <meta
           name="keywords"
-          content="nvidia jetson orin nano, device management, ota updates, yocto, embedded linux, industrial ai, robotics, fleet management"
+          content="advantech icam-540, industrial ai camera, nvidia jetson xavier nx, computer vision, ip67, poe+, fleet management"
         />
         <meta
           property="og:title"
-          content="NVIDIA Jetson Orin Nano Production Linux | Day 1 Ready | Peridio"
+          content="Advantech ICAM-540 Industrial AI Camera | Production Ready | Peridio"
         />
         <meta
           property="og:description"
-          content="Production-ready NVIDIA Jetson Orin Nano deployment from day 1 with Peridio Fleet + Avocado OS. Enterprise Linux and secure fleet management."
+          content="Deploy Advantech ICAM-540 industrial AI cameras with enterprise fleet management and secure OTA updates."
         />
-        <meta property="og:image" content="/img/nvidia-jetson-orin.jpg" />
+        <meta property="og:image" content="/img/advantech-icam-540.jpg" />
         <meta property="og:type" content="product" />
-        <link rel="canonical" href="https://docs.peridio.com/solutions/nvidia/jetson-orin-nano" />
+        <link rel="canonical" href="https://docs.peridio.com/solutions/advantech/icam-540" />
 
         {/* Structured Data */}
         <script type="application/ld+json">
           {JSON.stringify({
             '@context': 'https://schema.org',
             '@type': 'Product',
-            name: 'Peridio + Avocado OS for NVIDIA Jetson Orin Nano',
+            name: 'Peridio + Avocado OS for Advantech ICAM-540',
             description:
-              'Day 1 production-ready Linux and device management for NVIDIA Jetson Orin Nano with enterprise-grade embedded OS',
+              'Production-ready industrial AI camera with NVIDIA Jetson Xavier NX and enterprise fleet management',
             manufacturer: {
               '@type': 'Organization',
               name: 'Peridio',
             },
-            category: 'Device Management Software',
+            category: 'Industrial AI Camera',
             offers: {
               '@type': 'Offer',
               availability: 'https://schema.org/InStock',
             },
-            applicationCategory: 'Industrial AI, Robotics, Edge Computing',
+            applicationCategory: 'Computer Vision, Quality Inspection, Smart Factory',
             operatingSystem: 'Yocto Linux, Avocado OS',
           })}
         </script>
@@ -69,31 +69,29 @@ export default function JetsonOrinNanoSolution() {
           <div className={styles.heroContent}>
             <div className={styles.heroText}>
               <Heading as="h1" className={styles.heroTitle}>
-                Skip 18 Months of <span className={styles.highlight}>Jetson Development</span>
+                Industrial AI Vision with{' '}
+                <span className={styles.highlight}>Advantech ICAM-540</span>
               </Heading>
               <p className={styles.heroSubtitle}>
-                Deploy enterprise-grade NVIDIA Jetson Orin Nano fleets from day 1 with deterministic
-                Linux, secure OTA, and managed operations
+                IP67-rated smart camera with NVIDIA Jetson Xavier NX, 5MP global shutter, and PoE+
+                for harsh industrial environments
               </p>
               <div className={styles.heroStats}>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>Day 1</span>
-                  <span className={styles.statLabel}>Production Ready</span>
-                </div>
-                <div className={styles.stat}>
-                  <span className={styles.statNumber}>10+</span>
-                  <span className={styles.statLabel}>Year Support</span>
-                </div>
-                <div className={styles.stat}>
-                  <span className={styles.statNumber}>67</span>
+                  <span className={styles.statNumber}>21</span>
                   <span className={styles.statLabel}>TOPS AI Performance</span>
+                </div>
+                <div className={styles.stat}>
+                  <span className={styles.statNumber}>IP67</span>
+                  <span className={styles.statLabel}>Ruggedized Design</span>
+                </div>
+                <div className={styles.stat}>
+                  <span className={styles.statNumber}>PoE+</span>
+                  <span className={styles.statLabel}>Single Cable Solution</span>
                 </div>
               </div>
               <div className={styles.heroCta}>
-                <Link
-                  to="/dev-center/hardware/nvidia/jetson-orin-nano-evk"
-                  className={styles.ctaPrimary}
-                >
+                <Link to="/dev-center/hardware/production-ready/icam540" className={styles.ctaPrimary}>
                   Get Started
                 </Link>
                 <a href="https://peridio.com" className={styles.ctaSecondary} target="_blank" rel="noopener noreferrer">
@@ -103,8 +101,8 @@ export default function JetsonOrinNanoSolution() {
             </div>
             <div className={styles.heroImage}>
               <img
-                src="/img/jetson-nano.png"
-                alt="NVIDIA Jetson Orin Nano development kit"
+                src="/img/advantech-icam-540.jpg"
+                alt="Advantech ICAM-540 industrial AI camera"
                 className={styles.productImage}
               />
             </div>
@@ -116,38 +114,38 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.specs}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Hardware Specifications
+            ICAM-540 Technical Specifications
           </Heading>
           <div className={styles.specsTable}>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>AI Performance</div>
-              <div className={styles.specValue}>67 TOPS (8GB) / 34 TOPS (4GB)</div>
-              <div className={styles.specNote}>Up to 142× performance of Jetson Nano</div>
+              <div className={styles.specLabel}>AI Processor</div>
+              <div className={styles.specValue}>NVIDIA Jetson Xavier NX</div>
+              <div className={styles.specNote}>21 TOPS with 384 CUDA cores</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>GPU</div>
-              <div className={styles.specValue}>1024/512-core NVIDIA Ampere GPU</div>
-              <div className={styles.specNote}>CUDA-X and TensorRT for real-time inference</div>
+              <div className={styles.specLabel}>Camera Sensor</div>
+              <div className={styles.specValue}>5MP Global Shutter CMOS</div>
+              <div className={styles.specNote}>2448 x 2048 @ 75fps, low distortion</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>CPU</div>
-              <div className={styles.specValue}>6-core Arm Cortex-A78AE @ 1.7 GHz</div>
-              <div className={styles.specNote}>Armv8.2 64-bit with safety features</div>
+              <div className={styles.specLabel}>Lens Options</div>
+              <div className={styles.specValue}>C-Mount Compatible</div>
+              <div className={styles.specNote}>6mm/8mm/12mm/16mm/25mm available</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>Memory</div>
-              <div className={styles.specValue}>8GB/4GB LPDDR5</div>
-              <div className={styles.specNote}>102/51 GB/s bandwidth for multi-sensor vision</div>
+              <div className={styles.specLabel}>Environmental</div>
+              <div className={styles.specValue}>IP67, IK10 Rated</div>
+              <div className={styles.specNote}>Dust-proof, waterproof, vandal-resistant</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>Power</div>
-              <div className={styles.specValue}>7–25W</div>
-              <div className={styles.specNote}>Scalable to battery-powered devices</div>
+              <div className={styles.specLabel}>Power & Network</div>
+              <div className={styles.specValue}>PoE+ (IEEE 802.3at)</div>
+              <div className={styles.specNote}>Single cable for power and data</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>Operating Temperature</div>
-              <div className={styles.specValue}>-40°C to +70°C</div>
-              <div className={styles.specNote}>Rugged industrial environments</div>
+              <div className={styles.specLabel}>Operating Temp</div>
+              <div className={styles.specValue}>-30°C to +60°C</div>
+              <div className={styles.specNote}>Wide temperature for harsh environments</div>
             </div>
           </div>
         </div>
@@ -162,38 +160,38 @@ export default function JetsonOrinNanoSolution() {
           <div className={styles.useCaseGrid}>
             <div className={styles.useCase}>
               <img
-                src="/img/pedestrian-monitoring.png"
-                alt="Industrial Smart Cameras"
+                src="/img/factory-quality-inspection.png"
+                alt="Quality Inspection"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Industrial Smart Cameras</Heading>
+              <Heading as="h3">Quality Inspection</Heading>
               <p>
-                Multi-camera CSI input for AI tasks like object detection and quality inspection.
-                OTA supports model updates in production.
-              </p>
-            </div>
-            <div className={styles.useCase}>
-              <img
-                src="/img/traffic-flow-optimization.png"
-                alt="Autonomous Mobile Robots"
-                className={styles.useCaseImage}
-              />
-              <Heading as="h3">Autonomous Mobile Robots</Heading>
-              <p>
-                Real-time sensor fusion and navigation processing. Avocado OS supports ROS2 and
-                containers with scalable fleet rollouts.
+                Real-time defect detection on production lines with sub-millisecond inference.
+                Global shutter eliminates motion blur for high-speed inspection.
               </p>
             </div>
             <div className={styles.useCase}>
               <img
                 src="/img/workplace-safety.png"
-                alt="Edge AI Gateways"
+                alt="Safety Monitoring"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Edge AI Gateways</Heading>
+              <Heading as="h3">Safety Monitoring</Heading>
               <p>
-                Run generative AI or LLMs locally with NVMe and optional 10-GbE. Managed Linux keeps
-                them secure in harsh environments.
+                PPE compliance and hazard detection in industrial facilities. IP67 rating allows
+                deployment in harsh factory environments.
+              </p>
+            </div>
+            <div className={styles.useCase}>
+              <img
+                src="/img/pedestrian-monitoring.png"
+                alt="Logistics Automation"
+                className={styles.useCaseImage}
+              />
+              <Heading as="h3">Logistics Automation</Heading>
+              <p>
+                Barcode reading, OCR, and package tracking in warehouses. PoE+ simplifies
+                multi-camera deployments across facilities.
               </p>
             </div>
           </div>
@@ -205,7 +203,7 @@ export default function JetsonOrinNanoSolution() {
         <div className={styles.container}>
           <div className={styles.sectionHeader}>
             <Heading as="h2">From Challenge to Solution</Heading>
-            <p>Transform your Jetson development workflow with enterprise-grade infrastructure</p>
+            <p>Transform your industrial vision deployment with production-ready infrastructure</p>
           </div>
 
           <div className={styles.comparisonContainer}>
@@ -219,22 +217,20 @@ export default function JetsonOrinNanoSolution() {
               <div className={styles.cardContent}>
                 <div className={styles.challengeItem}>
                   <span className={styles.challengeText}>
-                    Developer kits aren&apos;t production-ready
+                    Complex multi-camera synchronization
                   </span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Custom Yocto builds take 6-18 months</span>
+                  <span className={styles.challengeText}>Manual model deployment to edge</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>
-                    OTA infrastructure requires dedicated teams
-                  </span>
+                  <span className={styles.challengeText}>No centralized camera management</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Security compliance adds complexity</span>
+                  <span className={styles.challengeText}>Difficult firmware updates</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Fleet management built from scratch</span>
+                  <span className={styles.challengeText}>Limited production diagnostics</span>
                 </div>
               </div>
             </div>
@@ -248,19 +244,19 @@ export default function JetsonOrinNanoSolution() {
               </div>
               <div className={styles.cardContent}>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Production-ready OS in minutes</span>
+                  <span className={styles.solutionText}>Synchronized multi-camera systems</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Pre-integrated Jetson BSPs</span>
+                  <span className={styles.solutionText}>OTA model and firmware updates</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Enterprise OTA orchestration</span>
+                  <span className={styles.solutionText}>Centralized fleet management</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Built-in security compliance</span>
+                  <span className={styles.solutionText}>Secure, atomic updates</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Managed fleet operations</span>
+                  <span className={styles.solutionText}>Remote monitoring and diagnostics</span>
                 </div>
               </div>
             </div>
@@ -272,67 +268,67 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.features}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Why Choose Peridio for Jetson Development
+            Why Choose Peridio for ICAM-540 Deployment
           </Heading>
           <div className={styles.featureGrid}>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
-                <RocketLaunchIcon style={{ width: '100%', height: '100%' }} />
+                <CameraIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Rapid Deployment</Heading>
+              <Heading as="h3">Production Vision OS</Heading>
               <p>
-                Boot deterministic Linux on Jetson in minutes. Hardware-in-the-loop tools reduce
-                iteration from weeks to hours.
+                Pre-configured Avocado OS with GStreamer, OpenCV, and DeepStream SDK. Optimized for
+                industrial computer vision workloads.
               </p>
             </div>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
-                <LockClosedIcon style={{ width: '100%', height: '100%' }} />
+                <CpuChipIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Production Security</Heading>
+              <Heading as="h3">AI Model Management</Heading>
               <p>
-                Secure boot, dm-verity, and LUKS encryption across all architectures. Reproducible
-                images simplify certification.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <WifiIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Fleet Management</Heading>
-              <p>
-                Register and manage devices in Peridio Fleet. Phased releases, cohort targeting,
-                SBOM, and CVE patching.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Composable Architecture</Heading>
-              <p>
-                Build systems using modular layers and standard secure components. Avoid the
-                fragility of DIY Yocto.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Cross-Platform</Heading>
-              <p>
-                Reuse Avocado OS layers across ARM/NPU SoCs (Qualcomm Rubik Pi 3, MediaTek Genio,
-                NXP i.MX8MP).
+                Deploy TensorRT-optimized models via OTA. A/B testing for model updates with
+                automatic rollback on accuracy degradation.
               </p>
             </div>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
                 <ShieldCheckIcon style={{ width: '100%', height: '100%' }} />
               </div>
+              <Heading as="h3">Enterprise Security</Heading>
+              <p>
+                Secure boot, encrypted storage, and certificate-based authentication. GDPR-compliant
+                edge processing without cloud dependencies.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Fleet Orchestration</Heading>
+              <p>
+                Manage hundreds of cameras across multiple sites. Cohort-based updates, scheduling,
+                and maintenance windows.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <BuildingOfficeIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Industrial Hardened</Heading>
+              <p>
+                IP67-rated hardware with watchdog timers and auto-recovery. Designed for 24/7
+                operation in harsh environments.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
+              </div>
               <Heading as="h3">Long-term Support</Heading>
               <p>
-                10+ years of kernel/security maintenance. Combined with Jetson&apos;s industrial
-                lifecycle ensures device longevity.
+                10-year hardware availability with enterprise Linux maintenance. Security patches
+                and compliance updates guaranteed.
               </p>
             </div>
           </div>
@@ -343,16 +339,13 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.cta}>
         <div className={styles.container}>
           <div className={styles.ctaContent}>
-            <Heading as="h2">Ready to Accelerate Your Jetson Development?</Heading>
+            <Heading as="h2">Ready to Deploy Industrial AI Vision?</Heading>
             <p>
-              Transform your NVIDIA Jetson Orin Nano from developer kit to secure, deployable
-              industrial AI platform.
+              Transform your Advantech ICAM-540 cameras into a managed fleet with secure OTA
+              updates, remote diagnostics, and enterprise support.
             </p>
             <div className={styles.ctaButtons}>
-              <Link
-                to="/dev-center/hardware/nvidia/jetson-orin-nano-evk"
-                className={styles.ctaPrimary}
-              >
+              <Link to="/dev-center/hardware/production-ready/icam540" className={styles.ctaPrimary}>
                 Get Started
               </Link>
               <Link to="https://avocadolinux.org" className={styles.ctaSecondary} target="_blank">
@@ -371,20 +364,20 @@ export default function JetsonOrinNanoSolution() {
           </Heading>
           <div className={styles.resourceGrid}>
             <Link to="/integration/linux/build-tools/yocto" className={styles.resourceCard}>
-              <Heading as="h3">Yocto Integration Guide</Heading>
-              <p>Step-by-step Yocto build configuration for Jetson Orin Nano</p>
+              <Heading as="h3">Vision System Integration</Heading>
+              <p>GStreamer pipelines and DeepStream configuration for industrial cameras</p>
             </Link>
             <Link to="/platform/reference/overview" className={styles.resourceCard}>
-              <Heading as="h3">Device Security</Heading>
-              <p>Device certificates, secure boot, and fleet security management</p>
+              <Heading as="h3">AI Model Deployment</Heading>
+              <p>TensorRT optimization and OTA model updates for edge inference</p>
             </Link>
             <Link to="/platform/reference/overview" className={styles.resourceCard}>
-              <Heading as="h3">Platform Overview</Heading>
-              <p>Complete Peridio platform architecture and capabilities</p>
+              <Heading as="h3">Camera Fleet Management</Heading>
+              <p>Multi-site camera orchestration with centralized monitoring</p>
             </Link>
             <Link to="/admin-api" className={styles.resourceCard}>
-              <Heading as="h3">API Documentation</Heading>
-              <p>REST API and GraphQL integration for fleet management</p>
+              <Heading as="h3">Vision API Integration</Heading>
+              <p>REST API for camera control and inference result streaming</p>
             </Link>
           </div>
         </div>

--- a/src/src/pages/solutions/advantech/icam-540.module.css
+++ b/src/src/pages/solutions/advantech/icam-540.module.css
@@ -1,4 +1,4 @@
-/* Raspberry Pi Landing Page - Peridio Brand Styles */
+/* i.MX 8M Plus Landing Page - Peridio Brand Styles */
 
 /* Hero Section - Matching Peridio Design */
 .hero {
@@ -429,6 +429,48 @@
   line-height: 1.4;
 }
 
+/* Productization Benefits */
+.benefits {
+  padding: 2rem;
+  background: var(--ifm-card-background-color);
+}
+
+.benefitGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.benefit {
+  flex: 1;
+  min-width: 250px;
+  max-width: 250px;
+  width: 250px;
+  height: 250px;
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 10px;
+  background: #f5f5f7;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.benefit h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: #333333;
+  font-family: "Avenir", sans-serif;
+  font-weight: bold;
+}
+
+.benefit p {
+  color: var(--ifm-color-content-secondary);
+  line-height: 1.6;
+  font-size: 14px;
+}
+
 /* Use Cases */
 .useCases {
   padding: 2rem;
@@ -651,6 +693,15 @@
 
   .specNote {
     font-size: 0.8rem;
+  }
+
+  .benefitGrid {
+    flex-direction: column;
+  }
+
+  .benefit {
+    min-width: 100%;
+    max-width: none;
   }
 
   .useCaseGrid {

--- a/src/src/pages/solutions/nxp/frdm-93.js
+++ b/src/src/pages/solutions/nxp/frdm-93.js
@@ -3,62 +3,62 @@ import Layout from '@theme/Layout'
 import Head from '@docusaurus/Head'
 import Link from '@docusaurus/Link'
 import Heading from '@theme/Heading'
-import styles from './jetson-orin-nano.module.css'
+import styles from './frdm-93.module.css'
 import {
-  HiOutlineRocketLaunch as RocketLaunchIcon,
-  HiOutlineLockClosed as LockClosedIcon,
-  HiOutlineWifi as WifiIcon,
-  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
-  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineCpuChip as CpuChipIcon,
+  HiOutlineBolt as BoltIcon,
   HiOutlineShieldCheck as ShieldCheckIcon,
+  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
+  HiOutlineBeaker as BeakerIcon,
+  HiOutlineChartBar as ChartBarIcon,
   HiOutlineXMark as XMarkIcon,
   HiOutlineCheck as CheckIcon,
 } from 'react-icons/hi2'
 
-export default function JetsonOrinNanoSolution() {
+export default function FRDM93Solution() {
   return (
     <Layout>
       <Head>
-        <title>NVIDIA Jetson Orin Nano Production Linux | Day 1 Ready | Peridio</title>
+        <title>NXP FRDM-MCXN947 MCU Development | Real-Time IoT | Peridio</title>
         <meta
           name="description"
-          content="Production-ready NVIDIA Jetson Orin Nano deployment from day 1 with Peridio Fleet + Avocado OS. Enterprise Linux, secure OTA, and fleet management for industrial AI."
+          content="Production-ready NXP FRDM-MCXN947 development with dual Cortex-M33 cores, ML acceleration, and secure IoT connectivity. Enterprise OTA and fleet management."
         />
         <meta
           name="keywords"
-          content="nvidia jetson orin nano, device management, ota updates, yocto, embedded linux, industrial ai, robotics, fleet management"
+          content="nxp frdm-mcxn947, mcx n94, cortex-m33, mcu development, real-time, iot, embedded, fleet management"
         />
         <meta
           property="og:title"
-          content="NVIDIA Jetson Orin Nano Production Linux | Day 1 Ready | Peridio"
+          content="NXP FRDM-MCXN947 MCU Development | Real-Time IoT | Peridio"
         />
         <meta
           property="og:description"
-          content="Production-ready NVIDIA Jetson Orin Nano deployment from day 1 with Peridio Fleet + Avocado OS. Enterprise Linux and secure fleet management."
+          content="Production-ready NXP FRDM-MCXN947 development with dual Cortex-M33 cores and enterprise fleet management."
         />
-        <meta property="og:image" content="/img/nvidia-jetson-orin.jpg" />
+        <meta property="og:image" content="/img/nxp-frdm-93.jpg" />
         <meta property="og:type" content="product" />
-        <link rel="canonical" href="https://docs.peridio.com/solutions/nvidia/jetson-orin-nano" />
+        <link rel="canonical" href="https://docs.peridio.com/solutions/nxp/frdm-93" />
 
         {/* Structured Data */}
         <script type="application/ld+json">
           {JSON.stringify({
             '@context': 'https://schema.org',
             '@type': 'Product',
-            name: 'Peridio + Avocado OS for NVIDIA Jetson Orin Nano',
+            name: 'Peridio + Avocado OS for NXP FRDM-MCXN947',
             description:
-              'Day 1 production-ready Linux and device management for NVIDIA Jetson Orin Nano with enterprise-grade embedded OS',
+              'Production-ready MCU development platform with dual-core Cortex-M33 and enterprise fleet management',
             manufacturer: {
               '@type': 'Organization',
               name: 'Peridio',
             },
-            category: 'Device Management Software',
+            category: 'MCU Development Platform',
             offers: {
               '@type': 'Offer',
               availability: 'https://schema.org/InStock',
             },
-            applicationCategory: 'Industrial AI, Robotics, Edge Computing',
-            operatingSystem: 'Yocto Linux, Avocado OS',
+            applicationCategory: 'Real-Time IoT, Industrial Control, ML Edge',
+            operatingSystem: 'FreeRTOS, Zephyr, Bare Metal',
           })}
         </script>
       </Head>
@@ -69,29 +69,30 @@ export default function JetsonOrinNanoSolution() {
           <div className={styles.heroContent}>
             <div className={styles.heroText}>
               <Heading as="h1" className={styles.heroTitle}>
-                Skip 18 Months of <span className={styles.highlight}>Jetson Development</span>
+                Industrial MCU Development with{' '}
+                <span className={styles.highlight}>NXP FRDM-MCXN947</span>
               </Heading>
               <p className={styles.heroSubtitle}>
-                Deploy enterprise-grade NVIDIA Jetson Orin Nano fleets from day 1 with deterministic
-                Linux, secure OTA, and managed operations
+                Dual-core Cortex-M33 platform with ML acceleration, secure boot, and industrial
+                connectivity for real-time IoT applications
               </p>
               <div className={styles.heroStats}>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>Day 1</span>
-                  <span className={styles.statLabel}>Production Ready</span>
+                  <span className={styles.statNumber}>150MHz</span>
+                  <span className={styles.statLabel}>Dual Cortex-M33</span>
                 </div>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>10+</span>
-                  <span className={styles.statLabel}>Year Support</span>
+                  <span className={styles.statNumber}>2MB</span>
+                  <span className={styles.statLabel}>Flash Memory</span>
                 </div>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>67</span>
-                  <span className={styles.statLabel}>TOPS AI Performance</span>
+                  <span className={styles.statNumber}>-40°C</span>
+                  <span className={styles.statLabel}>Industrial Temp</span>
                 </div>
               </div>
               <div className={styles.heroCta}>
                 <Link
-                  to="/dev-center/hardware/nvidia/jetson-orin-nano-evk"
+                  to="/dev-center/hardware/nxp/frdm-imx-93"
                   className={styles.ctaPrimary}
                 >
                   Get Started
@@ -103,8 +104,8 @@ export default function JetsonOrinNanoSolution() {
             </div>
             <div className={styles.heroImage}>
               <img
-                src="/img/jetson-nano.png"
-                alt="NVIDIA Jetson Orin Nano development kit"
+                src="/img/nxp-frdm-93.jpg"
+                alt="NXP FRDM-MCXN947 development board"
                 className={styles.productImage}
               />
             </div>
@@ -116,38 +117,38 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.specs}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Hardware Specifications
+            FRDM-MCXN947 Technical Specifications
           </Heading>
           <div className={styles.specsTable}>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>AI Performance</div>
-              <div className={styles.specValue}>67 TOPS (8GB) / 34 TOPS (4GB)</div>
-              <div className={styles.specNote}>Up to 142× performance of Jetson Nano</div>
-            </div>
-            <div className={styles.specsRow}>
-              <div className={styles.specLabel}>GPU</div>
-              <div className={styles.specValue}>1024/512-core NVIDIA Ampere GPU</div>
-              <div className={styles.specNote}>CUDA-X and TensorRT for real-time inference</div>
-            </div>
-            <div className={styles.specsRow}>
-              <div className={styles.specLabel}>CPU</div>
-              <div className={styles.specValue}>6-core Arm Cortex-A78AE @ 1.7 GHz</div>
-              <div className={styles.specNote}>Armv8.2 64-bit with safety features</div>
+              <div className={styles.specLabel}>Processor</div>
+              <div className={styles.specValue}>Dual Cortex-M33 @ 150MHz</div>
+              <div className={styles.specNote}>TrustZone security and DSP extensions</div>
             </div>
             <div className={styles.specsRow}>
               <div className={styles.specLabel}>Memory</div>
-              <div className={styles.specValue}>8GB/4GB LPDDR5</div>
-              <div className={styles.specNote}>102/51 GB/s bandwidth for multi-sensor vision</div>
+              <div className={styles.specValue}>2MB Flash / 512KB SRAM</div>
+              <div className={styles.specNote}>Execute-in-place from external flash</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>Power</div>
-              <div className={styles.specValue}>7–25W</div>
-              <div className={styles.specNote}>Scalable to battery-powered devices</div>
+              <div className={styles.specLabel}>ML Accelerator</div>
+              <div className={styles.specValue}>NPU with eIQ ML support</div>
+              <div className={styles.specNote}>TensorFlow Lite Micro optimized</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>Operating Temperature</div>
-              <div className={styles.specValue}>-40°C to +70°C</div>
-              <div className={styles.specNote}>Rugged industrial environments</div>
+              <div className={styles.specLabel}>Connectivity</div>
+              <div className={styles.specValue}>CAN FD, USB, UART, SPI, I2C</div>
+              <div className={styles.specNote}>Industrial protocols and automotive CAN</div>
+            </div>
+            <div className={styles.specsRow}>
+              <div className={styles.specLabel}>Security</div>
+              <div className={styles.specValue}>Secure Boot, Crypto, TRNG</div>
+              <div className={styles.specNote}>Hardware root of trust</div>
+            </div>
+            <div className={styles.specsRow}>
+              <div className={styles.specLabel}>Operating Temp</div>
+              <div className={styles.specValue}>-40°C to +105°C</div>
+              <div className={styles.specNote}>Automotive and industrial grade</div>
             </div>
           </div>
         </div>
@@ -157,43 +158,43 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.useCases}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Production Use Cases
+            Industrial Use Cases
           </Heading>
           <div className={styles.useCaseGrid}>
             <div className={styles.useCase}>
               <img
-                src="/img/pedestrian-monitoring.png"
-                alt="Industrial Smart Cameras"
+                src="/img/factory-quality-inspection.png"
+                alt="Industrial Sensor Hub"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Industrial Smart Cameras</Heading>
+              <Heading as="h3">Industrial Sensor Hub</Heading>
               <p>
-                Multi-camera CSI input for AI tasks like object detection and quality inspection.
-                OTA supports model updates in production.
+                Multi-sensor data fusion with ML inference at the edge. Dual-core architecture
+                separates real-time control from communication tasks.
               </p>
             </div>
             <div className={styles.useCase}>
               <img
-                src="/img/traffic-flow-optimization.png"
-                alt="Autonomous Mobile Robots"
+                src="/img/environmental-inspection.png"
+                alt="Motor Control Systems"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Autonomous Mobile Robots</Heading>
+              <Heading as="h3">Motor Control Systems</Heading>
               <p>
-                Real-time sensor fusion and navigation processing. Avocado OS supports ROS2 and
-                containers with scalable fleet rollouts.
+                FOC motor control with CAN FD for automotive and industrial applications. Hardware
+                PWM and encoder interfaces for precision control.
               </p>
             </div>
             <div className={styles.useCase}>
               <img
                 src="/img/workplace-safety.png"
-                alt="Edge AI Gateways"
+                alt="Secure IoT Gateway"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Edge AI Gateways</Heading>
+              <Heading as="h3">Secure IoT Gateway</Heading>
               <p>
-                Run generative AI or LLMs locally with NVMe and optional 10-GbE. Managed Linux keeps
-                them secure in harsh environments.
+                TrustZone-enabled secure gateway with hardware crypto. Bridge industrial sensors to
+                cloud with authenticated OTA updates.
               </p>
             </div>
           </div>
@@ -205,7 +206,7 @@ export default function JetsonOrinNanoSolution() {
         <div className={styles.container}>
           <div className={styles.sectionHeader}>
             <Heading as="h2">From Challenge to Solution</Heading>
-            <p>Transform your Jetson development workflow with enterprise-grade infrastructure</p>
+            <p>Transform your MCU development workflow with enterprise-grade infrastructure</p>
           </div>
 
           <div className={styles.comparisonContainer}>
@@ -219,22 +220,20 @@ export default function JetsonOrinNanoSolution() {
               <div className={styles.cardContent}>
                 <div className={styles.challengeItem}>
                   <span className={styles.challengeText}>
-                    Developer kits aren&apos;t production-ready
+                    Complex dual-core synchronization
                   </span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Custom Yocto builds take 6-18 months</span>
+                  <span className={styles.challengeText}>Manual firmware update processes</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>
-                    OTA infrastructure requires dedicated teams
-                  </span>
+                  <span className={styles.challengeText}>Limited debugging in production</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Security compliance adds complexity</span>
+                  <span className={styles.challengeText}>Security implementation overhead</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Fleet management built from scratch</span>
+                  <span className={styles.challengeText}>No fleet management for MCUs</span>
                 </div>
               </div>
             </div>
@@ -248,19 +247,19 @@ export default function JetsonOrinNanoSolution() {
               </div>
               <div className={styles.cardContent}>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Production-ready OS in minutes</span>
+                  <span className={styles.solutionText}>Pre-configured multicore RTOS</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Pre-integrated Jetson BSPs</span>
+                  <span className={styles.solutionText}>Secure OTA with rollback</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Enterprise OTA orchestration</span>
+                  <span className={styles.solutionText}>Remote diagnostics and logging</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Built-in security compliance</span>
+                  <span className={styles.solutionText}>Built-in secure boot chain</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Managed fleet operations</span>
+                  <span className={styles.solutionText}>Enterprise MCU fleet management</span>
                 </div>
               </div>
             </div>
@@ -272,67 +271,67 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.features}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Why Choose Peridio for Jetson Development
+            Why Choose Peridio for FRDM-MCXN947 Development
           </Heading>
           <div className={styles.featureGrid}>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
-                <RocketLaunchIcon style={{ width: '100%', height: '100%' }} />
+                <CpuChipIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Rapid Deployment</Heading>
+              <Heading as="h3">Dual-Core Optimization</Heading>
               <p>
-                Boot deterministic Linux on Jetson in minutes. Hardware-in-the-loop tools reduce
-                iteration from weeks to hours.
+                Pre-configured FreeRTOS/Zephyr with inter-core communication. Separate real-time
+                control from application logic seamlessly.
               </p>
             </div>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
-                <LockClosedIcon style={{ width: '100%', height: '100%' }} />
+                <BoltIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Production Security</Heading>
+              <Heading as="h3">Real-Time Performance</Heading>
               <p>
-                Secure boot, dm-verity, and LUKS encryption across all architectures. Reproducible
-                images simplify certification.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <WifiIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Fleet Management</Heading>
-              <p>
-                Register and manage devices in Peridio Fleet. Phased releases, cohort targeting,
-                SBOM, and CVE patching.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Composable Architecture</Heading>
-              <p>
-                Build systems using modular layers and standard secure components. Avoid the
-                fragility of DIY Yocto.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Cross-Platform</Heading>
-              <p>
-                Reuse Avocado OS layers across ARM/NPU SoCs (Qualcomm Rubik Pi 3, MediaTek Genio,
-                NXP i.MX8MP).
+                Deterministic execution with hardware PWM, timers, and DMA. Low-latency interrupt
+                handling for motor control and sensors.
               </p>
             </div>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
                 <ShieldCheckIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Long-term Support</Heading>
+              <Heading as="h3">Hardware Security</Heading>
               <p>
-                10+ years of kernel/security maintenance. Combined with Jetson&apos;s industrial
-                lifecycle ensures device longevity.
+                TrustZone isolation, secure boot, and hardware crypto. Device certificates and
+                secure key storage in PUF.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">MCU Fleet OTA</Heading>
+              <p>
+                Delta updates minimize bandwidth for constrained devices. A/B partitioning with
+                automatic rollback on failure.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <BeakerIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">ML at the Edge</Heading>
+              <p>
+                NPU-accelerated inference with TensorFlow Lite Micro. Pre-trained models for
+                anomaly detection and predictive maintenance.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <ChartBarIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Production Analytics</Heading>
+              <p>
+                Real-time telemetry and remote diagnostics. Monitor CPU usage, memory, and custom
+                metrics across your fleet.
               </p>
             </div>
           </div>
@@ -343,19 +342,20 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.cta}>
         <div className={styles.container}>
           <div className={styles.ctaContent}>
-            <Heading as="h2">Ready to Accelerate Your Jetson Development?</Heading>
+            <Heading as="h2">Ready to Accelerate Your MCU Development?</Heading>
             <p>
-              Transform your NVIDIA Jetson Orin Nano from developer kit to secure, deployable
-              industrial AI platform.
+              Transform your NXP FRDM-MCXN947 from development board to production-ready industrial
+              platform with secure OTA and fleet management.
             </p>
             <div className={styles.ctaButtons}>
-              <Link
-                to="/dev-center/hardware/nvidia/jetson-orin-nano-evk"
-                className={styles.ctaPrimary}
-              >
+              <Link to="/dev-center/hardware/nxp/frdm-imx-93" className={styles.ctaPrimary}>
                 Get Started
               </Link>
-              <Link to="https://avocadolinux.org" className={styles.ctaSecondary} target="_blank">
+              <Link
+                to="https://docs.avocadolinux.org/supported-hardware/frdm-mcxn947"
+                className={styles.ctaSecondary}
+                target="_blank"
+              >
                 Visit Avocado Linux
               </Link>
             </div>
@@ -371,20 +371,20 @@ export default function JetsonOrinNanoSolution() {
           </Heading>
           <div className={styles.resourceGrid}>
             <Link to="/integration/linux/build-tools/yocto" className={styles.resourceCard}>
-              <Heading as="h3">Yocto Integration Guide</Heading>
-              <p>Step-by-step Yocto build configuration for Jetson Orin Nano</p>
+              <Heading as="h3">MCU Development Guide</Heading>
+              <p>FreeRTOS and Zephyr configuration for dual-core Cortex-M33 platforms</p>
             </Link>
             <Link to="/platform/reference/overview" className={styles.resourceCard}>
-              <Heading as="h3">Device Security</Heading>
-              <p>Device certificates, secure boot, and fleet security management</p>
+              <Heading as="h3">Secure Boot Chain</Heading>
+              <p>Hardware root of trust with TrustZone and secure firmware updates</p>
             </Link>
             <Link to="/platform/reference/overview" className={styles.resourceCard}>
-              <Heading as="h3">Platform Overview</Heading>
-              <p>Complete Peridio platform architecture and capabilities</p>
+              <Heading as="h3">Fleet Management</Heading>
+              <p>MCU fleet operations with OTA updates and remote diagnostics</p>
             </Link>
             <Link to="/admin-api" className={styles.resourceCard}>
-              <Heading as="h3">API Documentation</Heading>
-              <p>REST API and GraphQL integration for fleet management</p>
+              <Heading as="h3">API Integration</Heading>
+              <p>REST API for automated testing and continuous deployment</p>
             </Link>
           </div>
         </div>

--- a/src/src/pages/solutions/nxp/frdm-93.module.css
+++ b/src/src/pages/solutions/nxp/frdm-93.module.css
@@ -1,4 +1,4 @@
-/* Raspberry Pi Landing Page - Peridio Brand Styles */
+/* i.MX 8M Plus Landing Page - Peridio Brand Styles */
 
 /* Hero Section - Matching Peridio Design */
 .hero {
@@ -429,6 +429,48 @@
   line-height: 1.4;
 }
 
+/* Productization Benefits */
+.benefits {
+  padding: 2rem;
+  background: var(--ifm-card-background-color);
+}
+
+.benefitGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.benefit {
+  flex: 1;
+  min-width: 250px;
+  max-width: 250px;
+  width: 250px;
+  height: 250px;
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 10px;
+  background: #f5f5f7;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.benefit h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: #333333;
+  font-family: "Avenir", sans-serif;
+  font-weight: bold;
+}
+
+.benefit p {
+  color: var(--ifm-color-content-secondary);
+  line-height: 1.6;
+  font-size: 14px;
+}
+
 /* Use Cases */
 .useCases {
   padding: 2rem;
@@ -651,6 +693,15 @@
 
   .specNote {
     font-size: 0.8rem;
+  }
+
+  .benefitGrid {
+    flex-direction: column;
+  }
+
+  .benefit {
+    min-width: 100%;
+    max-width: none;
   }
 
   .useCaseGrid {

--- a/src/src/pages/solutions/nxp/imx8mp.js
+++ b/src/src/pages/solutions/nxp/imx8mp.js
@@ -92,15 +92,14 @@ export default function IMX8MPSolution() {
               </div>
               <div className={styles.heroCta}>
                 <Link
-                  to="https://docs.avocadolinux.org/supported-hardware/imx-8m-plus"
+                  to="/dev-center/hardware/nxp/imx8mp"
                   className={styles.ctaPrimary}
-                  target="_blank"
                 >
                   Get Started
                 </Link>
-                <Link to="/platform/reference/overview" className={styles.ctaSecondary}>
+                <a href="https://peridio.com" className={styles.ctaSecondary} target="_blank" rel="noopener noreferrer">
                   Datasheet
-                </Link>
+                </a>
               </div>
             </div>
             <div className={styles.heroImage}>
@@ -394,8 +393,8 @@ export default function IMX8MPSolution() {
               ready for harsh environments.
             </p>
             <div className={styles.ctaButtons}>
-              <Link to="/evk" className={styles.ctaPrimary}>
-                Request Evaluation
+              <Link to="/dev-center/hardware/nxp/imx8mp" className={styles.ctaPrimary}>
+                Get Started
               </Link>
               <Link
                 to="https://docs.avocadolinux.org/supported-hardware/imx-8m-plus"

--- a/src/src/pages/solutions/onlogic/index.js
+++ b/src/src/pages/solutions/onlogic/index.js
@@ -3,61 +3,61 @@ import Layout from '@theme/Layout'
 import Head from '@docusaurus/Head'
 import Link from '@docusaurus/Link'
 import Heading from '@theme/Heading'
-import styles from './jetson-orin-nano.module.css'
+import styles from './index.module.css'
 import {
-  HiOutlineRocketLaunch as RocketLaunchIcon,
-  HiOutlineLockClosed as LockClosedIcon,
-  HiOutlineWifi as WifiIcon,
-  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
-  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineServerStack as ServerStackIcon,
+  HiOutlineFire as FireIcon,
   HiOutlineShieldCheck as ShieldCheckIcon,
+  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
+  HiOutlineBolt as BoltIcon,
   HiOutlineXMark as XMarkIcon,
   HiOutlineCheck as CheckIcon,
 } from 'react-icons/hi2'
 
-export default function JetsonOrinNanoSolution() {
+export default function FR201Solution() {
   return (
     <Layout>
       <Head>
-        <title>NVIDIA Jetson Orin Nano Production Linux | Day 1 Ready | Peridio</title>
+        <title>OnLogic FR201 Fanless Industrial PC | Rugged Edge Computing | Peridio</title>
         <meta
           name="description"
-          content="Production-ready NVIDIA Jetson Orin Nano deployment from day 1 with Peridio Fleet + Avocado OS. Enterprise Linux, secure OTA, and fleet management for industrial AI."
+          content="Deploy OnLogic FR201 fanless industrial PCs with Intel Core processors, wide temperature range, and enterprise fleet management. Production-ready edge computing."
         />
         <meta
           name="keywords"
-          content="nvidia jetson orin nano, device management, ota updates, yocto, embedded linux, industrial ai, robotics, fleet management"
+          content="onlogic fr201, fanless pc, industrial computer, edge computing, intel core, rugged, fleet management"
         />
         <meta
           property="og:title"
-          content="NVIDIA Jetson Orin Nano Production Linux | Day 1 Ready | Peridio"
+          content="OnLogic FR201 Fanless Industrial PC | Rugged Edge Computing | Peridio"
         />
         <meta
           property="og:description"
-          content="Production-ready NVIDIA Jetson Orin Nano deployment from day 1 with Peridio Fleet + Avocado OS. Enterprise Linux and secure fleet management."
+          content="Deploy OnLogic FR201 fanless industrial PCs with enterprise fleet management and secure OTA updates."
         />
-        <meta property="og:image" content="/img/nvidia-jetson-orin.jpg" />
+        <meta property="og:image" content="/img/onlogic-fr201.jpg" />
         <meta property="og:type" content="product" />
-        <link rel="canonical" href="https://docs.peridio.com/solutions/nvidia/jetson-orin-nano" />
+        <link rel="canonical" href="https://docs.peridio.com/solutions/onlogic" />
 
         {/* Structured Data */}
         <script type="application/ld+json">
           {JSON.stringify({
             '@context': 'https://schema.org',
             '@type': 'Product',
-            name: 'Peridio + Avocado OS for NVIDIA Jetson Orin Nano',
+            name: 'Peridio + Avocado OS for OnLogic FR201',
             description:
-              'Day 1 production-ready Linux and device management for NVIDIA Jetson Orin Nano with enterprise-grade embedded OS',
+              'Production-ready fanless industrial PC with Intel Core processors and enterprise fleet management',
             manufacturer: {
               '@type': 'Organization',
               name: 'Peridio',
             },
-            category: 'Device Management Software',
+            category: 'Industrial PC',
             offers: {
               '@type': 'Offer',
               availability: 'https://schema.org/InStock',
             },
-            applicationCategory: 'Industrial AI, Robotics, Edge Computing',
+            applicationCategory: 'Edge Computing, Industrial Gateway, Factory Automation',
             operatingSystem: 'Yocto Linux, Avocado OS',
           })}
         </script>
@@ -69,31 +69,29 @@ export default function JetsonOrinNanoSolution() {
           <div className={styles.heroContent}>
             <div className={styles.heroText}>
               <Heading as="h1" className={styles.heroTitle}>
-                Skip 18 Months of <span className={styles.highlight}>Jetson Development</span>
+                Rugged Edge Computing with{' '}
+                <span className={styles.highlight}>OnLogic FR201</span>
               </Heading>
               <p className={styles.heroSubtitle}>
-                Deploy enterprise-grade NVIDIA Jetson Orin Nano fleets from day 1 with deterministic
-                Linux, secure OTA, and managed operations
+                Fanless industrial PC with Intel Core i7/i5/i3, dual LAN, and -40°C to +70°C
+                operation for harsh edge environments
               </p>
               <div className={styles.heroStats}>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>Day 1</span>
-                  <span className={styles.statLabel}>Production Ready</span>
+                  <span className={styles.statNumber}>Fanless</span>
+                  <span className={styles.statLabel}>Silent Operation</span>
                 </div>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>10+</span>
-                  <span className={styles.statLabel}>Year Support</span>
+                  <span className={styles.statNumber}>-40°C</span>
+                  <span className={styles.statLabel}>Wide Temperature</span>
                 </div>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>67</span>
-                  <span className={styles.statLabel}>TOPS AI Performance</span>
+                  <span className={styles.statNumber}>24/7</span>
+                  <span className={styles.statLabel}>Continuous Operation</span>
                 </div>
               </div>
               <div className={styles.heroCta}>
-                <Link
-                  to="/dev-center/hardware/nvidia/jetson-orin-nano-evk"
-                  className={styles.ctaPrimary}
-                >
+                <Link to="/dev-center/hardware/production-ready/onlogic-factor" className={styles.ctaPrimary}>
                   Get Started
                 </Link>
                 <a href="https://peridio.com" className={styles.ctaSecondary} target="_blank" rel="noopener noreferrer">
@@ -103,8 +101,8 @@ export default function JetsonOrinNanoSolution() {
             </div>
             <div className={styles.heroImage}>
               <img
-                src="/img/jetson-nano.png"
-                alt="NVIDIA Jetson Orin Nano development kit"
+                src="/img/onlogic-fr201.jpg"
+                alt="OnLogic FR201 fanless industrial PC"
                 className={styles.productImage}
               />
             </div>
@@ -116,38 +114,38 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.specs}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Hardware Specifications
+            FR201 Technical Specifications
           </Heading>
           <div className={styles.specsTable}>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>AI Performance</div>
-              <div className={styles.specValue}>67 TOPS (8GB) / 34 TOPS (4GB)</div>
-              <div className={styles.specNote}>Up to 142× performance of Jetson Nano</div>
-            </div>
-            <div className={styles.specsRow}>
-              <div className={styles.specLabel}>GPU</div>
-              <div className={styles.specValue}>1024/512-core NVIDIA Ampere GPU</div>
-              <div className={styles.specNote}>CUDA-X and TensorRT for real-time inference</div>
-            </div>
-            <div className={styles.specsRow}>
-              <div className={styles.specLabel}>CPU</div>
-              <div className={styles.specValue}>6-core Arm Cortex-A78AE @ 1.7 GHz</div>
-              <div className={styles.specNote}>Armv8.2 64-bit with safety features</div>
+              <div className={styles.specLabel}>Processor</div>
+              <div className={styles.specValue}>Intel Core i7/i5/i3 (10th Gen)</div>
+              <div className={styles.specNote}>Up to 6 cores, 12 threads @ 4.7GHz</div>
             </div>
             <div className={styles.specsRow}>
               <div className={styles.specLabel}>Memory</div>
-              <div className={styles.specValue}>8GB/4GB LPDDR5</div>
-              <div className={styles.specNote}>102/51 GB/s bandwidth for multi-sensor vision</div>
+              <div className={styles.specValue}>Up to 64GB DDR4</div>
+              <div className={styles.specNote}>Dual-channel 2666MHz SO-DIMM</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>Power</div>
-              <div className={styles.specValue}>7–25W</div>
-              <div className={styles.specNote}>Scalable to battery-powered devices</div>
+              <div className={styles.specLabel}>Storage</div>
+              <div className={styles.specValue}>M.2 NVMe + 2.5&quot; SATA</div>
+              <div className={styles.specNote}>Hardware RAID support available</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>Operating Temperature</div>
+              <div className={styles.specLabel}>Networking</div>
+              <div className={styles.specValue}>Dual Intel GbE LAN</div>
+              <div className={styles.specNote}>Wake-on-LAN, PXE boot support</div>
+            </div>
+            <div className={styles.specsRow}>
+              <div className={styles.specLabel}>I/O Expansion</div>
+              <div className={styles.specValue}>4x USB 3.0, 2x COM, GPIO</div>
+              <div className={styles.specNote}>PCIe x16 slot for expansion cards</div>
+            </div>
+            <div className={styles.specsRow}>
+              <div className={styles.specLabel}>Operating Temp</div>
               <div className={styles.specValue}>-40°C to +70°C</div>
-              <div className={styles.specNote}>Rugged industrial environments</div>
+              <div className={styles.specNote}>Fanless cooling with heat pipe technology</div>
             </div>
           </div>
         </div>
@@ -157,43 +155,43 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.useCases}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Production Use Cases
+            Industrial Use Cases
           </Heading>
           <div className={styles.useCaseGrid}>
             <div className={styles.useCase}>
               <img
-                src="/img/pedestrian-monitoring.png"
-                alt="Industrial Smart Cameras"
+                src="/img/factory-quality-inspection.png"
+                alt="Factory Edge Gateway"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Industrial Smart Cameras</Heading>
+              <Heading as="h3">Factory Edge Gateway</Heading>
               <p>
-                Multi-camera CSI input for AI tasks like object detection and quality inspection.
-                OTA supports model updates in production.
+                Consolidate data from PLCs, sensors, and SCADA systems. Process and filter data at
+                the edge before cloud transmission.
+              </p>
+            </div>
+            <div className={styles.useCase}>
+              <img
+                src="/img/environmental-inspection.png"
+                alt="Machine Learning Inference"
+                className={styles.useCaseImage}
+              />
+              <Heading as="h3">ML Inference Server</Heading>
+              <p>
+                Run containerized AI workloads with Intel OpenVINO optimization. Local inference for
+                predictive maintenance and anomaly detection.
               </p>
             </div>
             <div className={styles.useCase}>
               <img
                 src="/img/traffic-flow-optimization.png"
-                alt="Autonomous Mobile Robots"
+                alt="Transportation Systems"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Autonomous Mobile Robots</Heading>
+              <Heading as="h3">Transportation Hub</Heading>
               <p>
-                Real-time sensor fusion and navigation processing. Avocado OS supports ROS2 and
-                containers with scalable fleet rollouts.
-              </p>
-            </div>
-            <div className={styles.useCase}>
-              <img
-                src="/img/workplace-safety.png"
-                alt="Edge AI Gateways"
-                className={styles.useCaseImage}
-              />
-              <Heading as="h3">Edge AI Gateways</Heading>
-              <p>
-                Run generative AI or LLMs locally with NVMe and optional 10-GbE. Managed Linux keeps
-                them secure in harsh environments.
+                Vehicle tracking, traffic management, and toll systems. Rugged design withstands
+                vibration and temperature extremes.
               </p>
             </div>
           </div>
@@ -205,7 +203,7 @@ export default function JetsonOrinNanoSolution() {
         <div className={styles.container}>
           <div className={styles.sectionHeader}>
             <Heading as="h2">From Challenge to Solution</Heading>
-            <p>Transform your Jetson development workflow with enterprise-grade infrastructure</p>
+            <p>Transform your edge computing deployment with enterprise-grade infrastructure</p>
           </div>
 
           <div className={styles.comparisonContainer}>
@@ -219,22 +217,20 @@ export default function JetsonOrinNanoSolution() {
               <div className={styles.cardContent}>
                 <div className={styles.challengeItem}>
                   <span className={styles.challengeText}>
-                    Developer kits aren&apos;t production-ready
+                    Windows IoT complexity and licensing
                   </span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Custom Yocto builds take 6-18 months</span>
+                  <span className={styles.challengeText}>Manual on-site updates required</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>
-                    OTA infrastructure requires dedicated teams
-                  </span>
+                  <span className={styles.challengeText}>No remote diagnostics capability</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Security compliance adds complexity</span>
+                  <span className={styles.challengeText}>Difficult multi-site management</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Fleet management built from scratch</span>
+                  <span className={styles.challengeText}>Limited production visibility</span>
                 </div>
               </div>
             </div>
@@ -248,19 +244,19 @@ export default function JetsonOrinNanoSolution() {
               </div>
               <div className={styles.cardContent}>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Production-ready OS in minutes</span>
+                  <span className={styles.solutionText}>Open-source Linux platform</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Pre-integrated Jetson BSPs</span>
+                  <span className={styles.solutionText}>Remote OTA updates and rollback</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Enterprise OTA orchestration</span>
+                  <span className={styles.solutionText}>Built-in remote diagnostics</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Built-in security compliance</span>
+                  <span className={styles.solutionText}>Centralized fleet management</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Managed fleet operations</span>
+                  <span className={styles.solutionText}>Real-time monitoring dashboard</span>
                 </div>
               </div>
             </div>
@@ -272,67 +268,67 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.features}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Why Choose Peridio for Jetson Development
+            Why Choose Peridio for FR201 Deployment
           </Heading>
           <div className={styles.featureGrid}>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
-                <RocketLaunchIcon style={{ width: '100%', height: '100%' }} />
+                <ServerStackIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Rapid Deployment</Heading>
+              <Heading as="h3">Edge-Optimized OS</Heading>
               <p>
-                Boot deterministic Linux on Jetson in minutes. Hardware-in-the-loop tools reduce
-                iteration from weeks to hours.
+                Lightweight Avocado OS with containers, K3s orchestration, and edge workload
+                optimization. Minimal footprint maximizes application resources.
               </p>
             </div>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
-                <LockClosedIcon style={{ width: '100%', height: '100%' }} />
+                <FireIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Production Security</Heading>
+              <Heading as="h3">Fanless Reliability</Heading>
               <p>
-                Secure boot, dm-verity, and LUKS encryption across all architectures. Reproducible
-                images simplify certification.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <WifiIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Fleet Management</Heading>
-              <p>
-                Register and manage devices in Peridio Fleet. Phased releases, cohort targeting,
-                SBOM, and CVE patching.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Composable Architecture</Heading>
-              <p>
-                Build systems using modular layers and standard secure components. Avoid the
-                fragility of DIY Yocto.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Cross-Platform</Heading>
-              <p>
-                Reuse Avocado OS layers across ARM/NPU SoCs (Qualcomm Rubik Pi 3, MediaTek Genio,
-                NXP i.MX8MP).
+                Thermal management optimizations for fanless operation. Automatic throttling and
+                workload distribution for 24/7 uptime.
               </p>
             </div>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
                 <ShieldCheckIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Long-term Support</Heading>
+              <Heading as="h3">Industrial Security</Heading>
               <p>
-                10+ years of kernel/security maintenance. Combined with Jetson&apos;s industrial
-                lifecycle ensures device longevity.
+                TPM 2.0 integration, secure boot, and full-disk encryption. Zero-trust architecture
+                with certificate-based authentication.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Multi-Site Management</Heading>
+              <p>
+                Deploy and manage thousands of edge nodes across locations. Site-specific
+                configurations with global policy enforcement.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Hardware Integration</Heading>
+              <p>
+                Pre-configured drivers for industrial protocols (Modbus, OPC-UA). GPIO control and
+                serial communication libraries included.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <BoltIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Resilient Updates</Heading>
+              <p>
+                Delta updates minimize bandwidth usage. Automatic rollback on failure with watchdog
+                timer integration.
               </p>
             </div>
           </div>
@@ -343,16 +339,13 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.cta}>
         <div className={styles.container}>
           <div className={styles.ctaContent}>
-            <Heading as="h2">Ready to Accelerate Your Jetson Development?</Heading>
+            <Heading as="h2">Ready to Deploy Rugged Edge Computing?</Heading>
             <p>
-              Transform your NVIDIA Jetson Orin Nano from developer kit to secure, deployable
-              industrial AI platform.
+              Transform your OnLogic FR201 systems into a managed fleet with secure OTA updates,
+              remote diagnostics, and enterprise support.
             </p>
             <div className={styles.ctaButtons}>
-              <Link
-                to="/dev-center/hardware/nvidia/jetson-orin-nano-evk"
-                className={styles.ctaPrimary}
-              >
+              <Link to="/dev-center/hardware/production-ready/onlogic-factor" className={styles.ctaPrimary}>
                 Get Started
               </Link>
               <Link to="https://avocadolinux.org" className={styles.ctaSecondary} target="_blank">
@@ -371,20 +364,20 @@ export default function JetsonOrinNanoSolution() {
           </Heading>
           <div className={styles.resourceGrid}>
             <Link to="/integration/linux/build-tools/yocto" className={styles.resourceCard}>
-              <Heading as="h3">Yocto Integration Guide</Heading>
-              <p>Step-by-step Yocto build configuration for Jetson Orin Nano</p>
+              <Heading as="h3">Edge Computing Guide</Heading>
+              <p>Container orchestration and workload management for industrial edge</p>
             </Link>
             <Link to="/platform/reference/overview" className={styles.resourceCard}>
-              <Heading as="h3">Device Security</Heading>
-              <p>Device certificates, secure boot, and fleet security management</p>
+              <Heading as="h3">Thermal Management</Heading>
+              <p>Fanless operation optimization and thermal monitoring</p>
             </Link>
             <Link to="/platform/reference/overview" className={styles.resourceCard}>
-              <Heading as="h3">Platform Overview</Heading>
-              <p>Complete Peridio platform architecture and capabilities</p>
+              <Heading as="h3">Fleet Operations</Heading>
+              <p>Multi-site edge node management with centralized control</p>
             </Link>
             <Link to="/admin-api" className={styles.resourceCard}>
-              <Heading as="h3">API Documentation</Heading>
-              <p>REST API and GraphQL integration for fleet management</p>
+              <Heading as="h3">Edge API Integration</Heading>
+              <p>REST API for edge application deployment and monitoring</p>
             </Link>
           </div>
         </div>

--- a/src/src/pages/solutions/onlogic/index.js.backup
+++ b/src/src/pages/solutions/onlogic/index.js.backup
@@ -1,0 +1,397 @@
+import React from 'react'
+import Layout from '@theme/Layout'
+import Head from '@docusaurus/Head'
+import Link from '@docusaurus/Link'
+import Heading from '@theme/Heading'
+import styles from './index.module.css'
+import {
+  HiOutlineServer as ServerIcon,
+  HiOutlineCpuChip as CpuChipIcon,
+  HiOutlineShieldCheck as ShieldCheckIcon,
+  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineBuildingOffice2 as BuildingOfficeIcon,
+  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
+  HiOutlineXMark as XMarkIcon,
+  HiOutlineCheck as CheckIcon,
+} from 'react-icons/hi2'
+
+export default function OnLogicSolution() {
+  return (
+    <Layout>
+      <Head>
+        <title>OnLogic Industrial Computers | Rugged Edge Computing | Peridio</title>
+        <meta
+          name="description"
+          content="Deploy OnLogic industrial computers with fanless designs, wide temperature ranges, and enterprise fleet management. Production-ready edge computing solutions."
+        />
+        <meta
+          name="keywords"
+          content="onlogic, industrial computers, fanless pc, edge computing, rugged computers, fleet management"
+        />
+        <meta
+          property="og:title"
+          content="OnLogic Industrial Computers | Rugged Edge Computing | Peridio"
+        />
+        <meta
+          property="og:description"
+          content="Deploy OnLogic industrial computers with enterprise fleet management and secure OTA updates."
+        />
+        <meta property="og:image" content="/img/onlogic-computers.jpg" />
+        <meta property="og:type" content="product" />
+        <link rel="canonical" href="https://docs.peridio.com/solutions/onlogic" />
+
+        {/* Structured Data */}
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Product',
+            name: 'Peridio + Avocado OS for OnLogic Industrial Computers',
+            description:
+              'Production-ready industrial edge computers with enterprise fleet management',
+            manufacturer: {
+              '@type': 'Organization',
+              name: 'Peridio',
+            },
+            category: 'Industrial Computing',
+            offers: {
+              '@type': 'Offer',
+              availability: 'https://schema.org/InStock',
+            },
+            applicationCategory: 'Edge Computing, IIoT, Factory Automation',
+            operatingSystem: 'Yocto Linux, Avocado OS',
+          })}
+        </script>
+      </Head>
+
+      {/* Hero Section */}
+      <section className={styles.hero}>
+        <div className={styles.heroContainer}>
+          <div className={styles.heroContent}>
+            <div className={styles.heroText}>
+              <Heading as="h1" className={styles.heroTitle}>
+                Industrial Edge Computing with{' '}
+                <span className={styles.highlight}>OnLogic</span>
+              </Heading>
+              <p className={styles.heroSubtitle}>
+                Fanless, rugged computers built for harsh environments with Intel and AMD processors
+                for mission-critical edge applications
+              </p>
+              <div className={styles.heroStats}>
+                <div className={styles.stat}>
+                  <span className={styles.statNumber}>-40°C</span>
+                  <span className={styles.statLabel}>to +70°C Operating</span>
+                </div>
+                <div className={styles.stat}>
+                  <span className={styles.statNumber}>IP65</span>
+                  <span className={styles.statLabel}>Dust & Water Resistant</span>
+                </div>
+                <div className={styles.stat}>
+                  <span className={styles.statNumber}>10+</span>
+                  <span className={styles.statLabel}>Years Availability</span>
+                </div>
+              </div>
+              <div className={styles.heroCta}>
+                <Link to="/evk" className={styles.ctaPrimary}>
+                  Request Demo
+                </Link>
+                <Link to="/platform/reference/overview" className={styles.ctaSecondary}>
+                  Platform Overview
+                </Link>
+              </div>
+            </div>
+            <div className={styles.heroImage}>
+              <img
+                src="/img/onlogic-computers.jpg"
+                alt="OnLogic industrial computers"
+                className={styles.productImage}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Featured Models */}
+      <section className={styles.models}>
+        <div className={styles.container}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Featured OnLogic Systems
+          </Heading>
+          <div className={styles.modelGrid}>
+            <Link to="/solutions/onlogic/fr201" className={styles.modelCard}>
+              <img
+                src="/img/onlogic-fr201.jpg"
+                alt="OnLogic FR201"
+                className={styles.modelImage}
+              />
+              <Heading as="h3">FR201 Panel PC</Heading>
+              <p className={styles.modelSpecs}>Intel Atom • 21.5&quot; Display • IP65</p>
+              <p>
+                Industrial HMI with projected capacitive touchscreen, perfect for factory floor
+                visualization and control systems.
+              </p>
+              <span className={styles.modelLink}>Learn More →</span>
+            </Link>
+            <div className={styles.modelCard}>
+              <img
+                src="/img/onlogic-karbon-700.jpg"
+                alt="OnLogic Karbon 700"
+                className={styles.modelImage}
+              />
+              <Heading as="h3">Karbon 700 Series</Heading>
+              <p className={styles.modelSpecs}>Intel Core/Xeon • Fanless • Rugged</p>
+              <p>
+                High-performance edge computing with Intel 12th Gen processors for AI inference
+                and real-time analytics.
+              </p>
+            </div>
+            <div className={styles.modelCard}>
+              <img
+                src="/img/onlogic-helix-600.jpg"
+                alt="OnLogic Helix 600"
+                className={styles.modelImage}
+              />
+              <Heading as="h3">Helix 600 Series</Heading>
+              <p className={styles.modelSpecs}>AMD Ryzen • Compact • Expandable</p>
+              <p>
+                Versatile industrial PC with multiple expansion slots for specialized I/O and
+                communication modules.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Use Cases */}
+      <section className={styles.useCases}>
+        <div className={styles.container}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Production Use Cases
+          </Heading>
+          <div className={styles.useCaseGrid}>
+            <div className={styles.useCase}>
+              <img
+                src="/img/factory-automation.png"
+                alt="Factory Automation"
+                className={styles.useCaseImage}
+              />
+              <Heading as="h3">Factory Automation</Heading>
+              <p>
+                PLC integration, SCADA systems, and MES deployment with real-time control and
+                monitoring in harsh industrial environments.
+              </p>
+            </div>
+            <div className={styles.useCase}>
+              <img
+                src="/img/edge-ai.png"
+                alt="Edge AI"
+                className={styles.useCaseImage}
+              />
+              <Heading as="h3">Edge AI & Vision</Heading>
+              <p>
+                Local inference for quality inspection, predictive maintenance, and computer vision
+                with GPU acceleration options.
+              </p>
+            </div>
+            <div className={styles.useCase}>
+              <img
+                src="/img/transportation.png"
+                alt="Transportation"
+                className={styles.useCaseImage}
+              />
+              <Heading as="h3">Transportation & Logistics</Heading>
+              <p>
+                Vehicle computers, fleet tracking, and warehouse automation with wide temperature
+                ranges and vibration resistance.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Problem/Solution Section */}
+      <section className={styles.problemSolution}>
+        <div className={styles.container}>
+          <div className={styles.sectionHeader}>
+            <Heading as="h2">From Challenge to Solution</Heading>
+            <p>Transform your industrial computing deployment with production-ready infrastructure</p>
+          </div>
+
+          <div className={styles.comparisonContainer}>
+            <div className={styles.challengeCard}>
+              <div className={styles.cardHeader}>
+                <div className={styles.challengeIcon}>
+                  <XMarkIcon style={{ width: '1.5rem', height: '1.5rem' }} />
+                </div>
+                <Heading as="h3">The Challenge</Heading>
+              </div>
+              <div className={styles.cardContent}>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>
+                    Manual system imaging and deployment
+                  </span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>No remote management capabilities</span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>Difficult field updates</span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>Inconsistent configurations</span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>Limited production visibility</span>
+                </div>
+              </div>
+            </div>
+
+            <div className={styles.solutionCard}>
+              <div className={styles.cardHeader}>
+                <div className={styles.solutionIcon}>
+                  <CheckIcon style={{ width: '1.5rem', height: '1.5rem' }} />
+                </div>
+                <Heading as="h3">The Solution</Heading>
+              </div>
+              <div className={styles.cardContent}>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Zero-touch provisioning</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Enterprise fleet management</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Secure OTA updates</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Configuration management</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Remote diagnostics & monitoring</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Key Features */}
+      <section className={styles.features}>
+        <div className={styles.container}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Why Choose Peridio for OnLogic Deployment
+          </Heading>
+          <div className={styles.featureGrid}>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <ServerIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Industrial Linux OS</Heading>
+              <p>
+                Pre-configured Avocado OS optimized for OnLogic hardware with real-time kernel
+                options and industrial protocol support.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <CpuChipIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Hardware Optimization</Heading>
+              <p>
+                BSP packages for OnLogic systems with validated drivers, thermal management, and
+                hardware watchdog support.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <ShieldCheckIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Security Hardening</Heading>
+              <p>
+                Secure boot, TPM integration, encrypted storage, and compliance with IEC 62443
+                industrial security standards.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Global Fleet Management</Heading>
+              <p>
+                Manage thousands of OnLogic systems across multiple sites with cohort-based updates
+                and maintenance windows.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <BuildingOfficeIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Industrial Protocols</Heading>
+              <p>
+                Built-in support for OPC UA, Modbus, EtherCAT, and PROFINET for seamless factory
+                floor integration.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Lifecycle Support</Heading>
+              <p>
+                10+ year support matching OnLogic hardware availability with continuous security
+                updates and compliance.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className={styles.cta}>
+        <div className={styles.container}>
+          <div className={styles.ctaContent}>
+            <Heading as="h2">Ready to Deploy OnLogic at Scale?</Heading>
+            <p>
+              Transform your OnLogic industrial computers into a managed fleet with secure OTA
+              updates, remote diagnostics, and enterprise support.
+            </p>
+            <div className={styles.ctaButtons}>
+              <Link to="/evk" className={styles.ctaPrimary}>
+                Request Evaluation
+              </Link>
+              <Link to="https://avocadolinux.org" className={styles.ctaSecondary} target="_blank">
+                Visit Avocado Linux
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related Resources */}
+      <section className={styles.resources}>
+        <div className={styles.container}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Documentation & Resources
+          </Heading>
+          <div className={styles.resourceGrid}>
+            <Link to="/integration/linux/build-tools/yocto" className={styles.resourceCard}>
+              <Heading as="h3">Industrial Linux Integration</Heading>
+              <p>Yocto BSP layers and real-time kernel configuration for OnLogic hardware</p>
+            </Link>
+            <Link to="/platform/reference/overview" className={styles.resourceCard}>
+              <Heading as="h3">Fleet Management Guide</Heading>
+              <p>Best practices for managing OnLogic deployments at scale</p>
+            </Link>
+            <Link to="/platform/reference/overview" className={styles.resourceCard}>
+              <Heading as="h3">Security Hardening</Heading>
+              <p>IEC 62443 compliance and industrial security configuration</p>
+            </Link>
+            <Link to="/admin-api" className={styles.resourceCard}>
+              <Heading as="h3">API Integration</Heading>
+              <p>REST APIs for fleet automation and monitoring integration</p>
+            </Link>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}

--- a/src/src/pages/solutions/onlogic/index.module.css
+++ b/src/src/pages/solutions/onlogic/index.module.css
@@ -1,4 +1,4 @@
-/* Raspberry Pi Landing Page - Peridio Brand Styles */
+/* i.MX 8M Plus Landing Page - Peridio Brand Styles */
 
 /* Hero Section - Matching Peridio Design */
 .hero {
@@ -429,6 +429,48 @@
   line-height: 1.4;
 }
 
+/* Productization Benefits */
+.benefits {
+  padding: 2rem;
+  background: var(--ifm-card-background-color);
+}
+
+.benefitGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.benefit {
+  flex: 1;
+  min-width: 250px;
+  max-width: 250px;
+  width: 250px;
+  height: 250px;
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 10px;
+  background: #f5f5f7;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.benefit h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: #333333;
+  font-family: "Avenir", sans-serif;
+  font-weight: bold;
+}
+
+.benefit p {
+  color: var(--ifm-color-content-secondary);
+  line-height: 1.6;
+  font-size: 14px;
+}
+
 /* Use Cases */
 .useCases {
   padding: 2rem;
@@ -651,6 +693,15 @@
 
   .specNote {
     font-size: 0.8rem;
+  }
+
+  .benefitGrid {
+    flex-direction: column;
+  }
+
+  .benefit {
+    min-width: 100%;
+    max-width: none;
   }
 
   .useCaseGrid {

--- a/src/src/pages/solutions/onlogic/index.module.css.backup
+++ b/src/src/pages/solutions/onlogic/index.module.css.backup
@@ -1,0 +1,496 @@
+/* Hero Section - Matching Peridio Design */
+.hero {
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000 100%),
+    url("/img/hero.png") lightgray -13px -1669.396px / 101.458% 1124.387% no-repeat;
+  color: white;
+  padding: 6rem 2.5rem;
+  position: relative;
+  overflow: hidden;
+  text-align: left;
+}
+
+.heroContainer {
+  max-width: 1200px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.heroContent {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 60px;
+  align-items: center;
+}
+
+.heroText {
+  max-width: 600px;
+}
+
+.heroTitle {
+  font-size: 2.1rem;
+  font-weight: bold;
+  line-height: 1.2;
+  margin-bottom: 0.125rem;
+  font-family: "Avenir", sans-serif;
+  color: white;
+}
+
+.highlight {
+  color: white;
+}
+
+.heroSubtitle {
+  font-size: 1.05rem;
+  font-weight: 500;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+  color: white;
+}
+
+.heroStats {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 2rem;
+  justify-content: flex-start;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.statNumber {
+  font-size: 2rem;
+  font-weight: bold;
+  color: white;
+  line-height: 1;
+  font-family: "Avenir", sans-serif;
+}
+
+.statLabel {
+  font-size: 0.875rem;
+  color: #bbb;
+  margin-top: 4px;
+}
+
+.heroCta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.ctaPrimary {
+  background: #5f51ff;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 1rem;
+  transition: background-color 0.2s;
+  font-family: "Avenir", sans-serif;
+}
+
+.ctaPrimary:hover {
+  background: #4a3dff;
+  color: white;
+  text-decoration: none;
+}
+
+.ctaSecondary {
+  background: none;
+  color: white;
+  padding: 0.5rem 1rem;
+  border: 1px solid #525860;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 1rem;
+  transition: all 0.2s;
+  font-family: "Avenir", sans-serif;
+}
+
+.ctaSecondary:hover {
+  background: #5f51ff;
+  border-color: #5f51ff;
+  color: white;
+  text-decoration: none;
+}
+
+.heroImage {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.productImage {
+  width: 400px;
+  height: 300px;
+  object-fit: cover;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Models Section */
+.models {
+  padding: 4rem 0;
+  background: #f8fafc;
+}
+
+.modelGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 2rem;
+  margin-top: 3rem;
+}
+
+.modelCard {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.modelCard:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+  text-decoration: none;
+  color: inherit;
+}
+
+.modelImage {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.modelCard h3 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: #0f172a;
+}
+
+.modelSpecs {
+  color: #10b981;
+  font-weight: 600;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.modelCard p {
+  color: #475569;
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+.modelLink {
+  color: #10b981;
+  font-weight: 600;
+  display: inline-block;
+  margin-top: 0.5rem;
+}
+
+/* Use Cases Section */
+.useCases {
+  padding: 4rem 0;
+  background: white;
+}
+
+.useCaseGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 3rem;
+  margin-top: 3rem;
+}
+
+.useCase {
+  text-align: center;
+}
+
+.useCaseImage {
+  width: 100%;
+  max-width: 300px;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.useCase h3 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.useCase p {
+  color: #475569;
+  line-height: 1.6;
+}
+
+/* Problem/Solution Section - Apple-inspired */
+.problemSolution {
+  padding: 3rem 2rem;
+  background: var(--ifm-card-background-color);
+  margin: 2rem 0;
+}
+
+.sectionHeader {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.sectionHeader h2 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.sectionHeader p {
+  font-size: 1.125rem;
+  color: #64748b;
+}
+
+.comparisonContainer {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.challengeCard,
+.solutionCard {
+  background: white;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.challengeIcon,
+.solutionIcon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.challengeIcon {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.solutionIcon {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.cardHeader h3 {
+  font-size: 1.5rem;
+  margin: 0;
+  color: #0f172a;
+}
+
+.cardContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.challengeItem,
+.solutionItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.challengeItem::before {
+  content: "✕";
+  color: #dc2626;
+  font-weight: bold;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.solutionItem::before {
+  content: "✓";
+  color: #16a34a;
+  font-weight: bold;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.challengeText,
+.solutionText {
+  color: #475569;
+  line-height: 1.5;
+}
+
+/* Features Section */
+.features {
+  padding: 4rem 0;
+  background: white;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.sectionTitle {
+  text-align: center;
+  font-size: 2.5rem;
+  margin-bottom: 3rem;
+  color: #0f172a;
+}
+
+.featureGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 3rem;
+}
+
+.feature {
+  text-align: center;
+}
+
+.featureIcon {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto 1.5rem;
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  border-radius: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+}
+
+.feature h3 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.feature p {
+  color: #475569;
+  line-height: 1.6;
+}
+
+/* CTA Section */
+.cta {
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+  color: white;
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.ctaContent h2 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.ctaContent p {
+  font-size: 1.125rem;
+  color: #cbd5e1;
+  margin-bottom: 2rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.ctaButtons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* Resources Section */
+.resources {
+  padding: 4rem 0;
+  background: #f8fafc;
+}
+
+.resourceGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  margin-top: 3rem;
+}
+
+.resourceCard {
+  background: white;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.resourceCard:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+  text-decoration: none;
+  color: inherit;
+}
+
+.resourceCard h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+  color: #0f172a;
+}
+
+.resourceCard p {
+  color: #64748b;
+  line-height: 1.5;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .heroContent {
+    grid-template-columns: 1fr;
+  }
+
+  .heroTitle {
+    font-size: 2rem;
+  }
+
+  .heroStats {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .comparisonContainer {
+    grid-template-columns: 1fr;
+  }
+
+  .featureGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .modelGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/src/pages/solutions/raspberry-pi/raspberry-pi.js
+++ b/src/src/pages/solutions/raspberry-pi/raspberry-pi.js
@@ -4,6 +4,16 @@ import Head from '@docusaurus/Head'
 import Link from '@docusaurus/Link'
 import Heading from '@theme/Heading'
 import styles from './raspberry-pi.module.css'
+import {
+  HiOutlineShieldCheck as ShieldCheckIcon,
+  HiOutlineWifi as WifiIcon,
+  HiOutlineLockClosed as LockClosedIcon,
+  HiOutlineBolt as BoltIcon,
+  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineChartBar as ChartBarIcon,
+  HiOutlineXMark as XMarkIcon,
+  HiOutlineCheck as CheckIcon,
+} from 'react-icons/hi2'
 
 export default function RaspberryPiSolution() {
   return (
@@ -80,12 +90,12 @@ export default function RaspberryPiSolution() {
                 </div>
               </div>
               <div className={styles.heroCta}>
-                <Link to="/evk" className={styles.ctaPrimary}>
-                  Start Free Demo →
+                <Link to="/dev-center/hardware/raspberry-pi/compute-module-4" className={styles.ctaPrimary}>
+                  Get Started →
                 </Link>
-                <Link to="/platform/reference/overview" className={styles.ctaSecondary}>
-                  View Documentation
-                </Link>
+                <a href="https://peridio.com" className={styles.ctaSecondary} target="_blank" rel="noopener noreferrer">
+                  Datasheet
+                </a>
               </div>
             </div>
             <div className={styles.heroImage}>
@@ -102,25 +112,69 @@ export default function RaspberryPiSolution() {
       {/* Problem/Solution Section */}
       <section className={styles.problemSolution}>
         <div className={styles.container}>
-          <div className={styles.problem}>
-            <Heading as="h2">The Raspberry Pi Production Gap</Heading>
-            <ul className={styles.problemList}>
-              <li>Prototypes work great, production deployment fails</li>
-              <li>SD card corruption in industrial environments</li>
-              <li>No secure OTA update mechanism</li>
-              <li>Manual fleet management doesn&apos;t scale</li>
-              <li>Security vulnerabilities in default OS</li>
-            </ul>
+          <div className={styles.sectionHeader}>
+            <Heading as="h2">From Challenge to Solution</Heading>
+            <p>
+              Transform your Raspberry Pi development workflow with enterprise-grade infrastructure
+            </p>
           </div>
-          <div className={styles.solution}>
-            <Heading as="h2">Peridio + Avocado OS Solution</Heading>
-            <ul className={styles.solutionList}>
-              <li>Production-hardened Linux OS</li>
-              <li>Read-only root with atomic updates</li>
-              <li>Enterprise OTA orchestration</li>
-              <li>Centralized fleet management</li>
-              <li>Built-in security compliance</li>
-            </ul>
+
+          <div className={styles.comparisonContainer}>
+            <div className={styles.challengeCard}>
+              <div className={styles.cardHeader}>
+                <div className={styles.challengeIcon}>
+                  <XMarkIcon style={{ width: '1.5rem', height: '1.5rem' }} />
+                </div>
+                <Heading as="h3">The Challenge</Heading>
+              </div>
+              <div className={styles.cardContent}>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>
+                    Prototypes work great, production deployment fails
+                  </span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>
+                    SD card corruption in industrial environments
+                  </span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>No secure OTA update mechanism</span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>Manual fleet management doesn&apos;t scale</span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>Security vulnerabilities in default OS</span>
+                </div>
+              </div>
+            </div>
+
+            <div className={styles.solutionCard}>
+              <div className={styles.cardHeader}>
+                <div className={styles.solutionIcon}>
+                  <CheckIcon style={{ width: '1.5rem', height: '1.5rem' }} />
+                </div>
+                <Heading as="h3">The Solution</Heading>
+              </div>
+              <div className={styles.cardContent}>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Production-hardened Linux OS</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Read-only root with atomic updates</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Enterprise OTA orchestration</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Centralized fleet management</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Built-in security compliance</span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </section>
@@ -133,7 +187,9 @@ export default function RaspberryPiSolution() {
           </Heading>
           <div className={styles.featureGrid}>
             <div className={styles.feature}>
-              <div className={styles.featureIcon}>🛡️</div>
+              <div className={styles.featureIcon}>
+                <ShieldCheckIcon style={{ width: '100%', height: '100%' }} />
+              </div>
               <Heading as="h3">Production Hardening</Heading>
               <p>
                 Read-only root filesystem, secure boot, and A/B partitioning eliminate SD card
@@ -141,7 +197,9 @@ export default function RaspberryPiSolution() {
               </p>
             </div>
             <div className={styles.feature}>
-              <div className={styles.featureIcon}>📡</div>
+              <div className={styles.featureIcon}>
+                <WifiIcon style={{ width: '100%', height: '100%' }} />
+              </div>
               <Heading as="h3">Fleet-Scale OTA</Heading>
               <p>
                 Deploy updates to thousands of devices with phased rollouts, rollback capabilities,
@@ -149,7 +207,9 @@ export default function RaspberryPiSolution() {
               </p>
             </div>
             <div className={styles.feature}>
-              <div className={styles.featureIcon}>🔒</div>
+              <div className={styles.featureIcon}>
+                <LockClosedIcon style={{ width: '100%', height: '100%' }} />
+              </div>
               <Heading as="h3">Zero-Trust Security</Heading>
               <p>
                 Code signing, device certificates, and encrypted communication secure your entire
@@ -157,7 +217,9 @@ export default function RaspberryPiSolution() {
               </p>
             </div>
             <div className={styles.feature}>
-              <div className={styles.featureIcon}>⚡</div>
+              <div className={styles.featureIcon}>
+                <BoltIcon style={{ width: '100%', height: '100%' }} />
+              </div>
               <Heading as="h3">Rapid Development</Heading>
               <p>
                 Pre-built Yocto layers and containerized applications accelerate your time-to-market
@@ -165,7 +227,9 @@ export default function RaspberryPiSolution() {
               </p>
             </div>
             <div className={styles.feature}>
-              <div className={styles.featureIcon}>🌐</div>
+              <div className={styles.featureIcon}>
+                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
+              </div>
               <Heading as="h3">Cross-Platform Ready</Heading>
               <p>
                 Develop on Pi, deploy across ARM architectures. Reuse software stacks on industrial
@@ -173,7 +237,9 @@ export default function RaspberryPiSolution() {
               </p>
             </div>
             <div className={styles.feature}>
-              <div className={styles.featureIcon}>📊</div>
+              <div className={styles.featureIcon}>
+                <ChartBarIcon style={{ width: '100%', height: '100%' }} />
+              </div>
               <Heading as="h3">Fleet Intelligence</Heading>
               <p>
                 Real-time telemetry, remote diagnostics, and predictive maintenance keep your
@@ -282,8 +348,8 @@ export default function RaspberryPiSolution() {
               enterprise-grade reliability.
             </p>
             <div className={styles.ctaButtons}>
-              <Link to="/evk" className={styles.ctaPrimary}>
-                Start Free Demo
+              <Link to="/dev-center/hardware/raspberry-pi/compute-module-4" className={styles.ctaPrimary}>
+                Get Started
               </Link>
               <Link to="https://avocadolinux.org" className={styles.ctaSecondary} target="_blank">
                 Visit Avocado Linux

--- a/src/src/pages/solutions/seeed/index.js
+++ b/src/src/pages/solutions/seeed/index.js
@@ -3,61 +3,61 @@ import Layout from '@theme/Layout'
 import Head from '@docusaurus/Head'
 import Link from '@docusaurus/Link'
 import Heading from '@theme/Heading'
-import styles from './jetson-orin-nano.module.css'
+import styles from './index.module.css'
 import {
-  HiOutlineRocketLaunch as RocketLaunchIcon,
-  HiOutlineLockClosed as LockClosedIcon,
-  HiOutlineWifi as WifiIcon,
-  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
-  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineDeviceTablet as DeviceTabletIcon,
+  HiOutlineCpuChip as CpuChipIcon,
   HiOutlineShieldCheck as ShieldCheckIcon,
+  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
+  HiOutlineCommandLine as CommandLineIcon,
   HiOutlineXMark as XMarkIcon,
   HiOutlineCheck as CheckIcon,
 } from 'react-icons/hi2'
 
-export default function JetsonOrinNanoSolution() {
+export default function ReTerminalSolution() {
   return (
     <Layout>
       <Head>
-        <title>NVIDIA Jetson Orin Nano Production Linux | Day 1 Ready | Peridio</title>
+        <title>Seeed reTerminal Industrial HMI | Raspberry Pi CM4 | Peridio</title>
         <meta
           name="description"
-          content="Production-ready NVIDIA Jetson Orin Nano deployment from day 1 with Peridio Fleet + Avocado OS. Enterprise Linux, secure OTA, and fleet management for industrial AI."
+          content="Deploy Seeed reTerminal industrial HMI with Raspberry Pi CM4, 5-inch touchscreen, and enterprise fleet management. Production-ready edge computing."
         />
         <meta
           name="keywords"
-          content="nvidia jetson orin nano, device management, ota updates, yocto, embedded linux, industrial ai, robotics, fleet management"
+          content="seeed reterminal, raspberry pi cm4, industrial hmi, touchscreen, edge computing, fleet management"
         />
         <meta
           property="og:title"
-          content="NVIDIA Jetson Orin Nano Production Linux | Day 1 Ready | Peridio"
+          content="Seeed reTerminal Industrial HMI | Raspberry Pi CM4 | Peridio"
         />
         <meta
           property="og:description"
-          content="Production-ready NVIDIA Jetson Orin Nano deployment from day 1 with Peridio Fleet + Avocado OS. Enterprise Linux and secure fleet management."
+          content="Deploy Seeed reTerminal industrial HMI with enterprise fleet management and secure OTA updates."
         />
-        <meta property="og:image" content="/img/nvidia-jetson-orin.jpg" />
+        <meta property="og:image" content="/img/seeed-reterminal.jpg" />
         <meta property="og:type" content="product" />
-        <link rel="canonical" href="https://docs.peridio.com/solutions/nvidia/jetson-orin-nano" />
+        <link rel="canonical" href="https://docs.peridio.com/solutions/seeed" />
 
         {/* Structured Data */}
         <script type="application/ld+json">
           {JSON.stringify({
             '@context': 'https://schema.org',
             '@type': 'Product',
-            name: 'Peridio + Avocado OS for NVIDIA Jetson Orin Nano',
+            name: 'Peridio + Avocado OS for Seeed reTerminal',
             description:
-              'Day 1 production-ready Linux and device management for NVIDIA Jetson Orin Nano with enterprise-grade embedded OS',
+              'Production-ready industrial HMI with Raspberry Pi CM4 and enterprise fleet management',
             manufacturer: {
               '@type': 'Organization',
               name: 'Peridio',
             },
-            category: 'Device Management Software',
+            category: 'Industrial HMI',
             offers: {
               '@type': 'Offer',
               availability: 'https://schema.org/InStock',
             },
-            applicationCategory: 'Industrial AI, Robotics, Edge Computing',
+            applicationCategory: 'HMI, Edge Computing, Industrial Control, IoT Gateway',
             operatingSystem: 'Yocto Linux, Avocado OS',
           })}
         </script>
@@ -69,31 +69,29 @@ export default function JetsonOrinNanoSolution() {
           <div className={styles.heroContent}>
             <div className={styles.heroText}>
               <Heading as="h1" className={styles.heroTitle}>
-                Skip 18 Months of <span className={styles.highlight}>Jetson Development</span>
+                Industrial HMI with{' '}
+                <span className={styles.highlight}>Seeed reTerminal</span>
               </Heading>
               <p className={styles.heroSubtitle}>
-                Deploy enterprise-grade NVIDIA Jetson Orin Nano fleets from day 1 with deterministic
-                Linux, secure OTA, and managed operations
+                5-inch multi-touch display powered by Raspberry Pi CM4 with wireless connectivity
+                and modular expansion for industrial control
               </p>
               <div className={styles.heroStats}>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>Day 1</span>
-                  <span className={styles.statLabel}>Production Ready</span>
+                  <span className={styles.statNumber}>5&quot;</span>
+                  <span className={styles.statLabel}>IPS Touchscreen</span>
                 </div>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>10+</span>
-                  <span className={styles.statLabel}>Year Support</span>
+                  <span className={styles.statNumber}>1.5GHz</span>
+                  <span className={styles.statLabel}>Quad-Core ARM</span>
                 </div>
                 <div className={styles.stat}>
-                  <span className={styles.statNumber}>67</span>
-                  <span className={styles.statLabel}>TOPS AI Performance</span>
+                  <span className={styles.statNumber}>IP64</span>
+                  <span className={styles.statLabel}>Front Panel</span>
                 </div>
               </div>
               <div className={styles.heroCta}>
-                <Link
-                  to="/dev-center/hardware/nvidia/jetson-orin-nano-evk"
-                  className={styles.ctaPrimary}
-                >
+                <Link to="/dev-center/hardware/production-ready/seeed-reterminal" className={styles.ctaPrimary}>
                   Get Started
                 </Link>
                 <a href="https://peridio.com" className={styles.ctaSecondary} target="_blank" rel="noopener noreferrer">
@@ -103,8 +101,8 @@ export default function JetsonOrinNanoSolution() {
             </div>
             <div className={styles.heroImage}>
               <img
-                src="/img/jetson-nano.png"
-                alt="NVIDIA Jetson Orin Nano development kit"
+                src="/img/seeed-reterminal.jpg"
+                alt="Seeed reTerminal industrial HMI"
                 className={styles.productImage}
               />
             </div>
@@ -116,38 +114,38 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.specs}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Hardware Specifications
+            reTerminal Technical Specifications
           </Heading>
           <div className={styles.specsTable}>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>AI Performance</div>
-              <div className={styles.specValue}>67 TOPS (8GB) / 34 TOPS (4GB)</div>
-              <div className={styles.specNote}>Up to 142× performance of Jetson Nano</div>
+              <div className={styles.specLabel}>Processor</div>
+              <div className={styles.specValue}>Raspberry Pi CM4</div>
+              <div className={styles.specNote}>Quad-core Cortex-A72 @ 1.5GHz</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>GPU</div>
-              <div className={styles.specValue}>1024/512-core NVIDIA Ampere GPU</div>
-              <div className={styles.specNote}>CUDA-X and TensorRT for real-time inference</div>
-            </div>
-            <div className={styles.specsRow}>
-              <div className={styles.specLabel}>CPU</div>
-              <div className={styles.specValue}>6-core Arm Cortex-A78AE @ 1.7 GHz</div>
-              <div className={styles.specNote}>Armv8.2 64-bit with safety features</div>
+              <div className={styles.specLabel}>Display</div>
+              <div className={styles.specValue}>5-inch IPS LCD</div>
+              <div className={styles.specNote}>1280x720, 10-point multi-touch</div>
             </div>
             <div className={styles.specsRow}>
               <div className={styles.specLabel}>Memory</div>
-              <div className={styles.specValue}>8GB/4GB LPDDR5</div>
-              <div className={styles.specNote}>102/51 GB/s bandwidth for multi-sensor vision</div>
+              <div className={styles.specValue}>2/4/8GB LPDDR4</div>
+              <div className={styles.specNote}>Up to 32GB eMMC storage</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>Power</div>
-              <div className={styles.specValue}>7–25W</div>
-              <div className={styles.specNote}>Scalable to battery-powered devices</div>
+              <div className={styles.specLabel}>Connectivity</div>
+              <div className={styles.specValue}>WiFi 5 + BT 5.0</div>
+              <div className={styles.specNote}>Gigabit Ethernet, dual USB</div>
             </div>
             <div className={styles.specsRow}>
-              <div className={styles.specLabel}>Operating Temperature</div>
-              <div className={styles.specValue}>-40°C to +70°C</div>
-              <div className={styles.specNote}>Rugged industrial environments</div>
+              <div className={styles.specLabel}>Expansion</div>
+              <div className={styles.specValue}>40-pin GPIO</div>
+              <div className={styles.specNote}>Compatible with reTerminal E10-1 modules</div>
+            </div>
+            <div className={styles.specsRow}>
+              <div className={styles.specLabel}>Operating Temp</div>
+              <div className={styles.specValue}>0°C to +50°C</div>
+              <div className={styles.specNote}>Industrial-grade components</div>
             </div>
           </div>
         </div>
@@ -162,38 +160,38 @@ export default function JetsonOrinNanoSolution() {
           <div className={styles.useCaseGrid}>
             <div className={styles.useCase}>
               <img
-                src="/img/pedestrian-monitoring.png"
-                alt="Industrial Smart Cameras"
+                src="/img/industrial-hmi.png"
+                alt="Industrial HMI"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Industrial Smart Cameras</Heading>
+              <Heading as="h3">Machine Control Interface</Heading>
               <p>
-                Multi-camera CSI input for AI tasks like object detection and quality inspection.
-                OTA supports model updates in production.
+                Real-time machine monitoring and control with responsive touch interface. Integrate
+                with PLCs via Modbus, OPC UA, and MQTT protocols.
               </p>
             </div>
             <div className={styles.useCase}>
               <img
-                src="/img/traffic-flow-optimization.png"
-                alt="Autonomous Mobile Robots"
+                src="/img/building-automation.png"
+                alt="Building Automation"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Autonomous Mobile Robots</Heading>
+              <Heading as="h3">Building Automation</Heading>
               <p>
-                Real-time sensor fusion and navigation processing. Avocado OS supports ROS2 and
-                containers with scalable fleet rollouts.
+                Smart building control panels for HVAC, lighting, and security systems. Node-RED
+                integration for visual programming.
               </p>
             </div>
             <div className={styles.useCase}>
               <img
-                src="/img/workplace-safety.png"
-                alt="Edge AI Gateways"
+                src="/img/iot-gateway.png"
+                alt="IoT Gateway"
                 className={styles.useCaseImage}
               />
-              <Heading as="h3">Edge AI Gateways</Heading>
+              <Heading as="h3">Edge IoT Gateway</Heading>
               <p>
-                Run generative AI or LLMs locally with NVMe and optional 10-GbE. Managed Linux keeps
-                them secure in harsh environments.
+                Collect, process, and visualize sensor data at the edge. LoRaWAN and Zigbee support
+                via expansion modules.
               </p>
             </div>
           </div>
@@ -205,7 +203,7 @@ export default function JetsonOrinNanoSolution() {
         <div className={styles.container}>
           <div className={styles.sectionHeader}>
             <Heading as="h2">From Challenge to Solution</Heading>
-            <p>Transform your Jetson development workflow with enterprise-grade infrastructure</p>
+            <p>Transform your reTerminal deployment with production-ready infrastructure</p>
           </div>
 
           <div className={styles.comparisonContainer}>
@@ -219,22 +217,20 @@ export default function JetsonOrinNanoSolution() {
               <div className={styles.cardContent}>
                 <div className={styles.challengeItem}>
                   <span className={styles.challengeText}>
-                    Developer kits aren&apos;t production-ready
+                    Manual SD card imaging for each device
                   </span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Custom Yocto builds take 6-18 months</span>
+                  <span className={styles.challengeText}>No remote HMI management</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>
-                    OTA infrastructure requires dedicated teams
-                  </span>
+                  <span className={styles.challengeText}>Difficult UI updates in field</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Security compliance adds complexity</span>
+                  <span className={styles.challengeText}>Limited security features</span>
                 </div>
                 <div className={styles.challengeItem}>
-                  <span className={styles.challengeText}>Fleet management built from scratch</span>
+                  <span className={styles.challengeText}>No fleet monitoring</span>
                 </div>
               </div>
             </div>
@@ -248,19 +244,19 @@ export default function JetsonOrinNanoSolution() {
               </div>
               <div className={styles.cardContent}>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Production-ready OS in minutes</span>
+                  <span className={styles.solutionText}>Zero-touch provisioning</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Pre-integrated Jetson BSPs</span>
+                  <span className={styles.solutionText}>Remote HMI configuration</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Enterprise OTA orchestration</span>
+                  <span className={styles.solutionText}>OTA UI and app updates</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Built-in security compliance</span>
+                  <span className={styles.solutionText}>Secure boot and encryption</span>
                 </div>
                 <div className={styles.solutionItem}>
-                  <span className={styles.solutionText}>Managed fleet operations</span>
+                  <span className={styles.solutionText}>Real-time fleet analytics</span>
                 </div>
               </div>
             </div>
@@ -272,67 +268,67 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.features}>
         <div className={styles.container}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Why Choose Peridio for Jetson Development
+            Why Choose Peridio for reTerminal Deployment
           </Heading>
           <div className={styles.featureGrid}>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
-                <RocketLaunchIcon style={{ width: '100%', height: '100%' }} />
+                <DeviceTabletIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Rapid Deployment</Heading>
+              <Heading as="h3">HMI-Optimized OS</Heading>
               <p>
-                Boot deterministic Linux on Jetson in minutes. Hardware-in-the-loop tools reduce
-                iteration from weeks to hours.
+                Pre-configured Avocado OS with Qt, Flutter, and web-based UI frameworks. Hardware
+                accelerated graphics with Wayland compositor.
               </p>
             </div>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
-                <LockClosedIcon style={{ width: '100%', height: '100%' }} />
+                <CpuChipIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Production Security</Heading>
+              <Heading as="h3">CM4 Optimization</Heading>
               <p>
-                Secure boot, dm-verity, and LUKS encryption across all architectures. Reproducible
-                images simplify certification.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <WifiIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Fleet Management</Heading>
-              <p>
-                Register and manage devices in Peridio Fleet. Phased releases, cohort targeting,
-                SBOM, and CVE patching.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Composable Architecture</Heading>
-              <p>
-                Build systems using modular layers and standard secure components. Avoid the
-                fragility of DIY Yocto.
-              </p>
-            </div>
-            <div className={styles.feature}>
-              <div className={styles.featureIcon}>
-                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
-              </div>
-              <Heading as="h3">Cross-Platform</Heading>
-              <p>
-                Reuse Avocado OS layers across ARM/NPU SoCs (Qualcomm Rubik Pi 3, MediaTek Genio,
-                NXP i.MX8MP).
+                Optimized for Raspberry Pi CM4 with GPU acceleration, hardware video decoding, and
+                efficient power management.
               </p>
             </div>
             <div className={styles.feature}>
               <div className={styles.featureIcon}>
                 <ShieldCheckIcon style={{ width: '100%', height: '100%' }} />
               </div>
-              <Heading as="h3">Long-term Support</Heading>
+              <Heading as="h3">Industrial Security</Heading>
               <p>
-                10+ years of kernel/security maintenance. Combined with Jetson&apos;s industrial
-                lifecycle ensures device longevity.
+                Secure boot chain, encrypted storage, and certificate-based authentication. Kiosk
+                mode for locked-down deployments.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Fleet Management</Heading>
+              <p>
+                Manage hundreds of reTerminals across multiple sites. Group-based configuration and
+                scheduled maintenance windows.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <CommandLineIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Protocol Support</Heading>
+              <p>
+                Built-in Modbus RTU/TCP, OPC UA, MQTT, and CoAP. Node-RED for visual flow-based
+                programming.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Developer Tools</Heading>
+              <p>
+                Remote debugging, log aggregation, and performance monitoring. SDK for custom
+                application development.
               </p>
             </div>
           </div>
@@ -343,16 +339,13 @@ export default function JetsonOrinNanoSolution() {
       <section className={styles.cta}>
         <div className={styles.container}>
           <div className={styles.ctaContent}>
-            <Heading as="h2">Ready to Accelerate Your Jetson Development?</Heading>
+            <Heading as="h2">Ready to Deploy reTerminal at Scale?</Heading>
             <p>
-              Transform your NVIDIA Jetson Orin Nano from developer kit to secure, deployable
-              industrial AI platform.
+              Transform your Seeed reTerminal HMIs into a managed fleet with secure OTA updates,
+              remote configuration, and enterprise support.
             </p>
             <div className={styles.ctaButtons}>
-              <Link
-                to="/dev-center/hardware/nvidia/jetson-orin-nano-evk"
-                className={styles.ctaPrimary}
-              >
+              <Link to="/dev-center/hardware/production-ready/seeed-reterminal" className={styles.ctaPrimary}>
                 Get Started
               </Link>
               <Link to="https://avocadolinux.org" className={styles.ctaSecondary} target="_blank">
@@ -371,20 +364,20 @@ export default function JetsonOrinNanoSolution() {
           </Heading>
           <div className={styles.resourceGrid}>
             <Link to="/integration/linux/build-tools/yocto" className={styles.resourceCard}>
-              <Heading as="h3">Yocto Integration Guide</Heading>
-              <p>Step-by-step Yocto build configuration for Jetson Orin Nano</p>
+              <Heading as="h3">HMI Development Guide</Heading>
+              <p>Qt and Flutter integration for reTerminal touchscreen applications</p>
             </Link>
             <Link to="/platform/reference/overview" className={styles.resourceCard}>
-              <Heading as="h3">Device Security</Heading>
-              <p>Device certificates, secure boot, and fleet security management</p>
+              <Heading as="h3">Industrial Protocols</Heading>
+              <p>Modbus, OPC UA, and MQTT configuration for industrial systems</p>
             </Link>
             <Link to="/platform/reference/overview" className={styles.resourceCard}>
-              <Heading as="h3">Platform Overview</Heading>
-              <p>Complete Peridio platform architecture and capabilities</p>
+              <Heading as="h3">Fleet Configuration</Heading>
+              <p>Managing HMI settings and UI updates across deployments</p>
             </Link>
             <Link to="/admin-api" className={styles.resourceCard}>
-              <Heading as="h3">API Documentation</Heading>
-              <p>REST API and GraphQL integration for fleet management</p>
+              <Heading as="h3">Remote Management API</Heading>
+              <p>REST APIs for HMI control and monitoring</p>
             </Link>
           </div>
         </div>

--- a/src/src/pages/solutions/seeed/index.js.backup
+++ b/src/src/pages/solutions/seeed/index.js.backup
@@ -1,0 +1,438 @@
+import React from 'react'
+import Layout from '@theme/Layout'
+import Head from '@docusaurus/Head'
+import Link from '@docusaurus/Link'
+import Heading from '@theme/Heading'
+import styles from './index.module.css'
+import {
+  HiOutlineCpuChip as CpuChipIcon,
+  HiOutlineBeaker as BeakerIcon,
+  HiOutlineShieldCheck as ShieldCheckIcon,
+  HiOutlineGlobeAlt as GlobeAltIcon,
+  HiOutlineBuildingOffice2 as BuildingOfficeIcon,
+  HiOutlineWrenchScrewdriver as WrenchScrewdriverIcon,
+  HiOutlineXMark as XMarkIcon,
+  HiOutlineCheck as CheckIcon,
+} from 'react-icons/hi2'
+
+export default function SeeedSolution() {
+  return (
+    <Layout>
+      <Head>
+        <title>Seeed Studio Development Boards | IoT & Edge AI | Peridio</title>
+        <meta
+          name="description"
+          content="Deploy Seeed Studio boards including reComputer, ODYSSEY, and Wio Terminal with enterprise fleet management. Production-ready IoT and edge AI solutions."
+        />
+        <meta
+          name="keywords"
+          content="seeed studio, recomputer, odyssey, wio terminal, iot boards, edge ai, nvidia jetson, fleet management"
+        />
+        <meta
+          property="og:title"
+          content="Seeed Studio Development Boards | IoT & Edge AI | Peridio"
+        />
+        <meta
+          property="og:description"
+          content="Deploy Seeed Studio boards with enterprise fleet management and secure OTA updates."
+        />
+        <meta property="og:image" content="/img/seeed-boards.jpg" />
+        <meta property="og:type" content="product" />
+        <link rel="canonical" href="https://docs.peridio.com/solutions/seeed" />
+
+        {/* Structured Data */}
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Product',
+            name: 'Peridio + Avocado OS for Seeed Studio Boards',
+            description:
+              'Production-ready IoT and edge AI boards with enterprise fleet management',
+            manufacturer: {
+              '@type': 'Organization',
+              name: 'Peridio',
+            },
+            category: 'IoT Development Boards',
+            offers: {
+              '@type': 'Offer',
+              availability: 'https://schema.org/InStock',
+            },
+            applicationCategory: 'IoT, Edge AI, Computer Vision, Industrial Automation',
+            operatingSystem: 'Yocto Linux, Avocado OS',
+          })}
+        </script>
+      </Head>
+
+      {/* Hero Section */}
+      <section className={styles.hero}>
+        <div className={styles.heroContainer}>
+          <div className={styles.heroContent}>
+            <div className={styles.heroText}>
+              <Heading as="h1" className={styles.heroTitle}>
+                Scale IoT & Edge AI with{' '}
+                <span className={styles.highlight}>Seeed Studio</span>
+              </Heading>
+              <p className={styles.heroSubtitle}>
+                From prototype to production with reComputer, ODYSSEY, and Wio Terminal boards
+                featuring NVIDIA Jetson and x86 processors
+              </p>
+              <div className={styles.heroStats}>
+                <div className={styles.stat}>
+                  <span className={styles.statNumber}>275</span>
+                  <span className={styles.statLabel}>TOPS with Orin</span>
+                </div>
+                <div className={styles.stat}>
+                  <span className={styles.statNumber}>100K+</span>
+                  <span className={styles.statLabel}>Developers</span>
+                </div>
+                <div className={styles.stat}>
+                  <span className={styles.statNumber}>5+</span>
+                  <span className={styles.statLabel}>Years Support</span>
+                </div>
+              </div>
+              <div className={styles.heroCta}>
+                <Link to="/evk" className={styles.ctaPrimary}>
+                  Request Demo
+                </Link>
+                <Link to="/platform/reference/overview" className={styles.ctaSecondary}>
+                  Platform Overview
+                </Link>
+              </div>
+            </div>
+            <div className={styles.heroImage}>
+              <img
+                src="/img/seeed-boards.jpg"
+                alt="Seeed Studio development boards"
+                className={styles.productImage}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Featured Products */}
+      <section className={styles.products}>
+        <div className={styles.container}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Featured Seeed Studio Products
+          </Heading>
+          <div className={styles.productGrid}>
+            <div className={styles.productCard}>
+              <img
+                src="/img/seeed-recomputer.jpg"
+                alt="reComputer Series"
+                className={styles.productImage}
+              />
+              <Heading as="h3">reComputer Series</Heading>
+              <p className={styles.productSpecs}>NVIDIA Jetson • Edge AI • Compact</p>
+              <p>
+                Industrial-grade Jetson carriers from Nano to Orin NX for AI inference, computer
+                vision, and robotics applications.
+              </p>
+              <ul className={styles.productFeatures}>
+                <li>Pre-installed JetPack SDK</li>
+                <li>Aluminum enclosure with passive cooling</li>
+                <li>Rich I/O: M.2, CSI, GPIO, Ethernet</li>
+              </ul>
+            </div>
+            <div className={styles.productCard}>
+              <img
+                src="/img/seeed-odyssey.jpg"
+                alt="ODYSSEY Boards"
+                className={styles.productImage}
+              />
+              <Heading as="h3">ODYSSEY x86 Boards</Heading>
+              <p className={styles.productSpecs}>Intel/AMD • Windows/Linux • Versatile</p>
+              <p>
+                x86 single board computers with Intel Celeron and AMD Ryzen processors for
+                industrial IoT and edge computing.
+              </p>
+              <ul className={styles.productFeatures}>
+                <li>Built-in Arduino coprocessor</li>
+                <li>Dual Gigabit Ethernet</li>
+                <li>M.2 NVMe and SATA support</li>
+              </ul>
+            </div>
+            <div className={styles.productCard}>
+              <img
+                src="/img/seeed-wio.jpg"
+                alt="Wio Terminal"
+                className={styles.productImage}
+              />
+              <Heading as="h3">Wio Terminal</Heading>
+              <p className={styles.productSpecs}>SAMD51 • Display • Wireless</p>
+              <p>
+                All-in-one IoT development platform with 2.4&quot; LCD, WiFi, Bluetooth, and Grove
+                ecosystem compatibility.
+              </p>
+              <ul className={styles.productFeatures}>
+                <li>Integrated display and buttons</li>
+                <li>WiFi and BLE connectivity</li>
+                <li>40-pin Raspberry Pi compatible header</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Use Cases */}
+      <section className={styles.useCases}>
+        <div className={styles.container}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Production Use Cases
+          </Heading>
+          <div className={styles.useCaseGrid}>
+            <div className={styles.useCase}>
+              <img
+                src="/img/smart-retail.png"
+                alt="Smart Retail"
+                className={styles.useCaseImage}
+              />
+              <Heading as="h3">Smart Retail & POS</Heading>
+              <p>
+                Customer analytics, inventory tracking, and intelligent checkout systems with
+                real-time AI processing at the edge.
+              </p>
+            </div>
+            <div className={styles.useCase}>
+              <img
+                src="/img/industrial-iot.png"
+                alt="Industrial IoT"
+                className={styles.useCaseImage}
+              />
+              <Heading as="h3">Industrial IoT</Heading>
+              <p>
+                Predictive maintenance, asset tracking, and environmental monitoring with LoRaWAN
+                and cellular connectivity options.
+              </p>
+            </div>
+            <div className={styles.useCase}>
+              <img
+                src="/img/robotics.png"
+                alt="Robotics"
+                className={styles.useCaseImage}
+              />
+              <Heading as="h3">Robotics & Automation</Heading>
+              <p>
+                Autonomous navigation, object detection, and manipulation with ROS2 support and
+                CUDA acceleration on Jetson platforms.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Problem/Solution Section */}
+      <section className={styles.problemSolution}>
+        <div className={styles.container}>
+          <div className={styles.sectionHeader}>
+            <Heading as="h2">From Prototype to Production</Heading>
+            <p>Bridge the gap between development boards and scalable deployments</p>
+          </div>
+
+          <div className={styles.comparisonContainer}>
+            <div className={styles.challengeCard}>
+              <div className={styles.cardHeader}>
+                <div className={styles.challengeIcon}>
+                  <XMarkIcon style={{ width: '1.5rem', height: '1.5rem' }} />
+                </div>
+                <Heading as="h3">The Challenge</Heading>
+              </div>
+              <div className={styles.cardContent}>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>
+                    Manual SD card flashing for each device
+                  </span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>No production OS support</span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>Difficult remote management</span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>Limited security features</span>
+                </div>
+                <div className={styles.challengeItem}>
+                  <span className={styles.challengeText}>No fleet visibility</span>
+                </div>
+              </div>
+            </div>
+
+            <div className={styles.solutionCard}>
+              <div className={styles.cardHeader}>
+                <div className={styles.solutionIcon}>
+                  <CheckIcon style={{ width: '1.5rem', height: '1.5rem' }} />
+                </div>
+                <Heading as="h3">The Solution</Heading>
+              </div>
+              <div className={styles.cardContent}>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Zero-touch provisioning</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Production-ready Avocado OS</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Enterprise fleet management</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Secure boot and encryption</span>
+                </div>
+                <div className={styles.solutionItem}>
+                  <span className={styles.solutionText}>Real-time monitoring & analytics</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Key Features */}
+      <section className={styles.features}>
+        <div className={styles.container}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Why Choose Peridio for Seeed Deployment
+          </Heading>
+          <div className={styles.featureGrid}>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <CpuChipIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Optimized BSPs</Heading>
+              <p>
+                Board support packages for reComputer, ODYSSEY, and Wio platforms with validated
+                drivers and hardware acceleration.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <BeakerIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Development to Production</Heading>
+              <p>
+                Seamless transition from prototyping to mass production with consistent tooling and
+                infrastructure.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <ShieldCheckIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Security First</Heading>
+              <p>
+                Hardware security modules, secure boot, encrypted storage, and compliance with IoT
+                security standards.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <GlobeAltIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Global Deployment</Heading>
+              <p>
+                Deploy and manage Seeed boards worldwide with regional update servers and bandwidth
+                optimization.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <BuildingOfficeIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">AI/ML Pipeline</Heading>
+              <p>
+                Integrated MLOps for model deployment, A/B testing, and performance monitoring on
+                Jetson platforms.
+              </p>
+            </div>
+            <div className={styles.feature}>
+              <div className={styles.featureIcon}>
+                <WrenchScrewdriverIcon style={{ width: '100%', height: '100%' }} />
+              </div>
+              <Heading as="h3">Developer Friendly</Heading>
+              <p>
+                Compatible with Arduino, CircuitPython, and standard Linux development workflows.
+                Extensive SDK and API support.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Ecosystem Section */}
+      <section className={styles.ecosystem}>
+        <div className={styles.container}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Seeed Ecosystem Support
+          </Heading>
+          <div className={styles.ecosystemGrid}>
+            <div className={styles.ecosystemItem}>
+              <Heading as="h3">Grove Modules</Heading>
+              <p>Full support for 300+ Grove sensors and actuators with pre-built drivers</p>
+            </div>
+            <div className={styles.ecosystemItem}>
+              <Heading as="h3">SenseCAP Platform</Heading>
+              <p>Integration with SenseCAP IoT sensors for environmental monitoring</p>
+            </div>
+            <div className={styles.ecosystemItem}>
+              <Heading as="h3">Edge Impulse</Heading>
+              <p>Deploy TinyML models with optimized inference on Seeed hardware</p>
+            </div>
+            <div className={styles.ecosystemItem}>
+              <Heading as="h3">ROS2 Support</Heading>
+              <p>Pre-configured ROS2 packages for robotics and automation projects</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className={styles.cta}>
+        <div className={styles.container}>
+          <div className={styles.ctaContent}>
+            <Heading as="h2">Ready to Scale Your Seeed Deployment?</Heading>
+            <p>
+              Transform your Seeed Studio boards into production-ready devices with secure OTA
+              updates, remote management, and enterprise support.
+            </p>
+            <div className={styles.ctaButtons}>
+              <Link to="/evk" className={styles.ctaPrimary}>
+                Request Evaluation
+              </Link>
+              <Link to="https://avocadolinux.org" className={styles.ctaSecondary} target="_blank">
+                Visit Avocado Linux
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related Resources */}
+      <section className={styles.resources}>
+        <div className={styles.container}>
+          <Heading as="h2" className={styles.sectionTitle}>
+            Documentation & Resources
+          </Heading>
+          <div className={styles.resourceGrid}>
+            <Link to="/integration/linux/build-tools/yocto" className={styles.resourceCard}>
+              <Heading as="h3">Seeed BSP Integration</Heading>
+              <p>Yocto layers and device trees for Seeed boards</p>
+            </Link>
+            <Link to="/platform/reference/overview" className={styles.resourceCard}>
+              <Heading as="h3">Jetson Optimization</Heading>
+              <p>CUDA, TensorRT, and DeepStream configuration guides</p>
+            </Link>
+            <Link to="/platform/reference/overview" className={styles.resourceCard}>
+              <Heading as="h3">IoT Connectivity</Heading>
+              <p>LoRaWAN, cellular, and WiFi provisioning guides</p>
+            </Link>
+            <Link to="/admin-api" className={styles.resourceCard}>
+              <Heading as="h3">Fleet Automation</Heading>
+              <p>APIs for device provisioning and management</p>
+            </Link>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}

--- a/src/src/pages/solutions/seeed/index.module.css
+++ b/src/src/pages/solutions/seeed/index.module.css
@@ -1,4 +1,4 @@
-/* Raspberry Pi Landing Page - Peridio Brand Styles */
+/* i.MX 8M Plus Landing Page - Peridio Brand Styles */
 
 /* Hero Section - Matching Peridio Design */
 .hero {
@@ -429,6 +429,48 @@
   line-height: 1.4;
 }
 
+/* Productization Benefits */
+.benefits {
+  padding: 2rem;
+  background: var(--ifm-card-background-color);
+}
+
+.benefitGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.benefit {
+  flex: 1;
+  min-width: 250px;
+  max-width: 250px;
+  width: 250px;
+  height: 250px;
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 10px;
+  background: #f5f5f7;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.benefit h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: #333333;
+  font-family: "Avenir", sans-serif;
+  font-weight: bold;
+}
+
+.benefit p {
+  color: var(--ifm-color-content-secondary);
+  line-height: 1.6;
+  font-size: 14px;
+}
+
 /* Use Cases */
 .useCases {
   padding: 2rem;
@@ -651,6 +693,15 @@
 
   .specNote {
     font-size: 0.8rem;
+  }
+
+  .benefitGrid {
+    flex-direction: column;
+  }
+
+  .benefit {
+    min-width: 100%;
+    max-width: none;
   }
 
   .useCaseGrid {

--- a/src/src/pages/solutions/seeed/index.module.css.backup
+++ b/src/src/pages/solutions/seeed/index.module.css.backup
@@ -1,0 +1,539 @@
+/* Hero Section - Matching Peridio Design */
+.hero {
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000 100%),
+    url("/img/hero.png") lightgray -13px -1669.396px / 101.458% 1124.387% no-repeat;
+  color: white;
+  padding: 6rem 2.5rem;
+  position: relative;
+  overflow: hidden;
+  text-align: left;
+}
+
+.heroContainer {
+  max-width: 1200px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.heroContent {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 60px;
+  align-items: center;
+}
+
+.heroText {
+  max-width: 600px;
+}
+
+.heroTitle {
+  font-size: 2.1rem;
+  font-weight: bold;
+  line-height: 1.2;
+  margin-bottom: 0.125rem;
+  font-family: "Avenir", sans-serif;
+  color: white;
+}
+
+.highlight {
+  color: white;
+}
+
+.heroSubtitle {
+  font-size: 1.05rem;
+  font-weight: 500;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+  color: white;
+}
+
+.heroStats {
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 2rem;
+  justify-content: flex-start;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.statNumber {
+  font-size: 2rem;
+  font-weight: bold;
+  color: white;
+  line-height: 1;
+  font-family: "Avenir", sans-serif;
+}
+
+.statLabel {
+  font-size: 0.875rem;
+  color: #bbb;
+  margin-top: 4px;
+}
+
+.heroCta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.ctaPrimary {
+  background: #5f51ff;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 1rem;
+  transition: background-color 0.2s;
+  font-family: "Avenir", sans-serif;
+}
+
+.ctaPrimary:hover {
+  background: #4a3dff;
+  color: white;
+  text-decoration: none;
+}
+
+.ctaSecondary {
+  background: none;
+  color: white;
+  padding: 0.5rem 1rem;
+  border: 1px solid #525860;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 1rem;
+  transition: all 0.2s;
+  font-family: "Avenir", sans-serif;
+}
+
+.ctaSecondary:hover {
+  background: #5f51ff;
+  border-color: #5f51ff;
+  color: white;
+  text-decoration: none;
+}
+
+.heroImage {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.productImage {
+  width: 400px;
+  height: 300px;
+  object-fit: cover;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Products Section */
+.products {
+  padding: 4rem 0;
+  background: #f8fafc;
+}
+
+.productGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 2rem;
+  margin-top: 3rem;
+}
+
+.productCard {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s;
+}
+
+.productCard:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+}
+
+.productCard img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.productCard h3 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+  color: #0f172a;
+}
+
+.productSpecs {
+  color: #10b981;
+  font-weight: 600;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.productCard p {
+  color: #475569;
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+.productFeatures {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.productFeatures li {
+  color: #64748b;
+  padding-left: 1.5rem;
+  position: relative;
+  margin-bottom: 0.5rem;
+}
+
+.productFeatures li::before {
+  content: "→";
+  position: absolute;
+  left: 0;
+  color: #10b981;
+}
+
+/* Use Cases Section */
+.useCases {
+  padding: 4rem 0;
+  background: white;
+}
+
+.useCaseGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 3rem;
+  margin-top: 3rem;
+}
+
+.useCase {
+  text-align: center;
+}
+
+.useCaseImage {
+  width: 100%;
+  max-width: 300px;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.useCase h3 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.useCase p {
+  color: #475569;
+  line-height: 1.6;
+}
+
+/* Problem/Solution Section - Apple-inspired */
+.problemSolution {
+  padding: 3rem 2rem;
+  background: var(--ifm-card-background-color);
+  margin: 2rem 0;
+}
+
+.sectionHeader {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.sectionHeader h2 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.sectionHeader p {
+  font-size: 1.125rem;
+  color: #64748b;
+}
+
+.comparisonContainer {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.challengeCard,
+.solutionCard {
+  background: white;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.challengeIcon,
+.solutionIcon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.challengeIcon {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.solutionIcon {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.cardHeader h3 {
+  font-size: 1.5rem;
+  margin: 0;
+  color: #0f172a;
+}
+
+.cardContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.challengeItem,
+.solutionItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.challengeItem::before {
+  content: "✕";
+  color: #dc2626;
+  font-weight: bold;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.solutionItem::before {
+  content: "✓";
+  color: #16a34a;
+  font-weight: bold;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.challengeText,
+.solutionText {
+  color: #475569;
+  line-height: 1.5;
+}
+
+/* Features Section */
+.features {
+  padding: 4rem 0;
+  background: white;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.sectionTitle {
+  text-align: center;
+  font-size: 2.5rem;
+  margin-bottom: 3rem;
+  color: #0f172a;
+}
+
+.featureGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 3rem;
+}
+
+.feature {
+  text-align: center;
+}
+
+.featureIcon {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto 1.5rem;
+  background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+  border-radius: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+}
+
+.feature h3 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.feature p {
+  color: #475569;
+  line-height: 1.6;
+}
+
+/* Ecosystem Section */
+.ecosystem {
+  padding: 4rem 0;
+  background: #f8fafc;
+}
+
+.ecosystemGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  margin-top: 3rem;
+}
+
+.ecosystemItem {
+  background: white;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.ecosystemItem h3 {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+  color: #0f172a;
+}
+
+.ecosystemItem p {
+  color: #475569;
+  line-height: 1.5;
+}
+
+/* CTA Section */
+.cta {
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+  color: white;
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.ctaContent h2 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.ctaContent p {
+  font-size: 1.125rem;
+  color: #cbd5e1;
+  margin-bottom: 2rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.ctaButtons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* Resources Section */
+.resources {
+  padding: 4rem 0;
+  background: white;
+}
+
+.resourceGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  margin-top: 3rem;
+}
+
+.resourceCard {
+  background: #f8fafc;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.resourceCard:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+  text-decoration: none;
+  color: inherit;
+}
+
+.resourceCard h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+  color: #0f172a;
+}
+
+.resourceCard p {
+  color: #64748b;
+  line-height: 1.5;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .heroContent {
+    grid-template-columns: 1fr;
+  }
+
+  .heroTitle {
+    font-size: 2rem;
+  }
+
+  .heroStats {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .comparisonContainer {
+    grid-template-columns: 1fr;
+  }
+
+  .featureGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .productGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .ecosystemGrid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
- Created marketing pages for OnLogic FR201 and Seeed reTerminal
- Updated all marketing pages to use consistent CTAs:
  - Primary: "Get Started" linking to interior dev docs
  - Secondary: "Datasheet" linking to peridio.com (placeholder)
- Updated mega navigation:
  - Logo now links to peridio.com
  - Changed "Get Started" to "Developer Home" linking to docs.peridio.com
  - Updated hardware links to point to specific products
- Matched all page styling with ICAM-540 design system
- Fixed all broken links to interior documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
