### PR TITLE
Update solution pages CTAs and sidebar navigation

### DIFF
--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -405,19 +405,16 @@ export default {
           },
           items: [
             {
-              type: 'doc',
-              id: 'dev-center/hardware/production-ready/seeed-reterminal',
-              label: 'Seeed reTerminal',
+              type: 'html',
+              value: '<a href="/solutions/seeed" target="_blank" rel="noopener noreferrer" class="menu__link" style="display: block;">Seeed reTerminal</a>',
             },
             {
-              type: 'doc',
-              id: 'dev-center/hardware/production-ready/icam540',
-              label: 'iCam540',
+              type: 'html',
+              value: '<a href="/solutions/advantech/icam-540" target="_blank" rel="noopener noreferrer" class="menu__link" style="display: block;">Advantech ICAM-540</a>',
             },
             {
-              type: 'doc',
-              id: 'dev-center/hardware/production-ready/onlogic-factor',
-              label: 'OnLogic Factor 201/202',
+              type: 'html',
+              value: '<a href="/solutions/onlogic" target="_blank" rel="noopener noreferrer" class="menu__link" style="display: block;">OnLogic FR201</a>',
             },
           ],
         },

--- a/src/src/pages/solutions/advantech/icam-540.js
+++ b/src/src/pages/solutions/advantech/icam-540.js
@@ -20,11 +20,11 @@ const solutionData = {
     ],
     primaryCTA: {
       text: "Get Started",
-      link: "/dev-center/hardware/production-ready/icam540"
+      link: "/dev-center/hardware/nvidia/jetson-orin-nano-evk"
     },
     secondaryCTA: {
-      text: "Datasheet",
-      link: "/"
+      text: "Request Demo",
+      link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/hardware/advantech/advantech-icam540.png",
     imageAlt: "Advantech ICAM-540 industrial AI camera"
@@ -143,7 +143,7 @@ const solutionData = {
     description: "Transform your Advantech ICAM-540 cameras into a managed vision fleet with atomic updates, remote diagnostics, and enterprise support.",
     primaryButton: {
       text: "Get Started",
-      link: "/dev-center/hardware/production-ready/icam540"
+      link: "/dev-center/hardware/nvidia/jetson-orin-nano-evk"
     },
     secondaryButton: {
       text: "Request a Demo",

--- a/src/src/pages/solutions/nvidia/jetson-orin-nano.js
+++ b/src/src/pages/solutions/nvidia/jetson-orin-nano.js
@@ -22,8 +22,8 @@ const solutionData = {
       link: "/dev-center/hardware/nvidia/jetson-orin-nano-evk"
     },
     secondaryCTA: {
-      text: "Datasheet",
-      link: "/"
+      text: "Request Demo",
+      link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/jetson-nano.png",
     imageAlt: "NVIDIA Jetson Orin Nano development kit"

--- a/src/src/pages/solutions/nxp/frdm-93.js
+++ b/src/src/pages/solutions/nxp/frdm-93.js
@@ -22,8 +22,8 @@ const solutionData = {
       link: "/dev-center/hardware/nxp/frdm-imx-93"
     },
     secondaryCTA: {
-      text: "Datasheet",
-      link: "/"
+      text: "Request Demo",
+      link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/hardware/nxp/NXP-FRDM-MCXN947.png",
     imageAlt: "NXP FRDM i.MX 93 development board"

--- a/src/src/pages/solutions/nxp/imx8mp.js
+++ b/src/src/pages/solutions/nxp/imx8mp.js
@@ -22,8 +22,8 @@ const solutionData = {
       link: "/dev-center/hardware/nxp/imx8mp"
     },
     secondaryCTA: {
-      text: "Datasheet",
-      link: "/"
+      text: "Request Demo",
+      link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/nxp_iMX8M_Plus.png",
     imageAlt: "NXP i.MX 8M Plus development board"

--- a/src/src/pages/solutions/onlogic/index.js
+++ b/src/src/pages/solutions/onlogic/index.js
@@ -19,10 +19,10 @@ const solutionData = {
     ],
     primaryCTA: {
       text: "Get Started",
-      link: "/dev-center/hardware/production-ready/onlogic-factor"
+      link: "/dev-center/hardware/raspberry-pi/compute-module-4"
     },
     secondaryCTA: {
-      text: "Request a Demo",
+      text: "Request Demo",
       link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/hardware/onlogic/OnLogic-FR201.png",
@@ -139,7 +139,7 @@ const solutionData = {
     description: "Transform your OnLogic FR201 systems into a managed gateway fleet with atomic updates, remote diagnostics, and enterprise support.",
     primaryButton: {
       text: "Get Started",
-      link: "/dev-center/hardware/production-ready/onlogic-factor"
+      link: "/dev-center/hardware/raspberry-pi/compute-module-4"
     },
     secondaryButton: {
       text: "Request a Demo",

--- a/src/src/pages/solutions/qualcomm/iq-9.js
+++ b/src/src/pages/solutions/qualcomm/iq-9.js
@@ -22,8 +22,8 @@ const solutionData = {
       link: "/evk"
     },
     secondaryCTA: {
-      text: "Datasheet",
-      link: "/platform/reference/overview"
+      text: "Request Demo",
+      link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/Qualcomm-IQ9.png",
     imageAlt: "Qualcomm IQ-9 QCS8550 development platform"

--- a/src/src/pages/solutions/qualcomm/rubik-pi.js
+++ b/src/src/pages/solutions/qualcomm/rubik-pi.js
@@ -22,8 +22,8 @@ const solutionData = {
       link: "/evk"
     },
     secondaryCTA: {
-      text: "Datasheet",
-      link: "/platform/reference/overview"
+      text: "Request Demo",
+      link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/Qualcomm-Rubikpi.png",
     imageAlt: "Qualcomm Rubik Pi RB3 Gen 2 development kit"

--- a/src/src/pages/solutions/raspberry-pi/raspberry-pi.js
+++ b/src/src/pages/solutions/raspberry-pi/raspberry-pi.js
@@ -22,8 +22,8 @@ const solutionData = {
       link: "/dev-center/hardware/raspberry-pi/compute-module-4"
     },
     secondaryCTA: {
-      text: "Datasheet",
-      link: "/"
+      text: "Request Demo",
+      link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/hardware/raspberry-pi/raspberrypi.png",
     imageAlt: "Raspberry Pi development board"

--- a/src/src/pages/solutions/seeed/index.js
+++ b/src/src/pages/solutions/seeed/index.js
@@ -22,11 +22,11 @@ const solutionData = {
     ],
     primaryCTA: {
       text: "Get Started",
-      link: "/dev-center/hardware/production-ready/seeed-reterminal"
+      link: "/dev-center/hardware/raspberry-pi/compute-module-4"
     },
     secondaryCTA: {
-      text: "Datasheet",
-      link: "/"
+      text: "Request Demo",
+      link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/hardware/seeed/seeed_reterminal.png",
     imageAlt: "Seeed reTerminal industrial HMI"
@@ -142,7 +142,7 @@ const solutionData = {
     description: "Transform your Seeed reTerminal HMIs into a production fleet. Get deterministic Linux, secure OTA orchestration, and enterprise fleet management - all production-ready from Day 1.",
     primaryButton: {
       text: "Get Started",
-      link: "/dev-center/hardware/production-ready/seeed-reterminal"
+      link: "/dev-center/hardware/raspberry-pi/compute-module-4"
     },
     secondaryButton: {
       text: "Visit Avocado Linux",

--- a/src/src/pages/solutions/stmicro/stm32mp157d-dk.js
+++ b/src/src/pages/solutions/stmicro/stm32mp157d-dk.js
@@ -23,8 +23,8 @@ const solutionData = {
       target: "_blank"
     },
     secondaryCTA: {
-      text: "Datasheet",
-      link: "/platform/reference/overview"
+      text: "Request Demo",
+      link: "https://peridio.com/book-a-meeting"
     },
     image: "/img/stmicro_STM32MP257F-DK.png",
     imageAlt: "STMicroelectronics STM32MP257F-DK development kit"


### PR DESCRIPTION
## Summary
- Updated production-ready hardware CTAs to link to appropriate Getting Started documentation
- Changed all secondary CTAs from "Datasheet" to "Request Demo" across solution pages
- Modified sidebar navigation to link directly to marketing/solutions pages

## Changes

### Production-Ready Hardware Links
Updated primary CTAs for production-ready targets to point to their respective Getting Started sections:
- **ICAM540** → `/dev-center/hardware/nvidia/jetson-orin-nano-evk` (NVIDIA Jetson documentation)
- **OnLogic FR201** → `/dev-center/hardware/raspberry-pi/compute-module-4` (Raspberry Pi CM4 documentation)
- **Seeed reTerminal** → `/dev-center/hardware/raspberry-pi/compute-module-4` (Raspberry Pi CM4 documentation)

### Secondary CTA Updates
Changed all 10 solution pages to replace "Datasheet" links with "Request Demo" buttons pointing to `https://peridio.com/book-a-meeting`

### Sidebar Navigation
Updated the production-ready hardware section in the sidebar to link directly to marketing/solutions pages instead of documentation pages.

**Implementation Note:** Used HTML anchor tags with `target="_blank"` attribute since Docusaurus doesn't support the `target` property on standard sidebar link items. Applied the `menu__link` class to maintain consistent hover effects and styling with other sidebar items.

## Test Plan
- [x] Verified all links work correctly
- [x] Confirmed hover effects are preserved on sidebar items
- [x] Ran `npm run lint` - no errors
- [x] Ran `npm run build` - builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)