### PR TITLE
Reorganize documentation navigation structure

### DIFF
--- a/src/docs/dev-center/getting-started/desktop-deploy.md
+++ b/src/docs/dev-center/getting-started/desktop-deploy.md
@@ -1,0 +1,11 @@
+---
+title: Desktop Deploy
+---
+
+# Desktop Deploy
+
+:::caution Under Development
+This guide is currently under active development. Content and procedures may change as we refine the desktop deployment process.
+:::
+
+This guide provides a comprehensive step-by-step walkthrough for deploying firmware updates directly from your desktop to embedded devices using Avocado OS's powerful sideloading capabilities. By leveraging Avocado OS sideloading, you can rapidly test and deploy firmware iterations without requiring a full cloud infrastructure setup, making it ideal for development environments, proof-of-concepts, and situations where direct device access is preferred. This approach streamlines the development workflow by allowing you to push updates directly from your workstation to target devices while maintaining the security and reliability features built into the Avocado OS update system.

--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -240,6 +240,11 @@ export default {
           id: 'dev-center/getting-started/hardware-in-the-loop',
           label: 'Hardware in the Loop',
         },
+        {
+          type: 'doc',
+          id: 'dev-center/getting-started/desktop-deploy',
+          label: 'Desktop Deploy',
+        },
         // {
         //   type: 'doc',
         //   id: 'dev-center/getting-started/first-ota-update',
@@ -434,9 +439,18 @@ export default {
       collapsible: true,
       collapsed: true,
       items: [
-        'dev-center/integration/peridio-core-rapid-setup',
+        {
+          type: 'category',
+          label: 'Peridio Core Rapid Setup',
+          link: {
+            type: 'doc',
+            id: 'dev-center/integration/peridio-core-rapid-setup',
+          },
+          items: [
+            'dev-center/integration/evk',
+          ],
+        },
         'dev-center/integration/peridiod-agent',
-        'dev-center/integration/evk',
         'dev-center/integration/cloud-delegated-updates',
         {
           type: 'category',


### PR DESCRIPTION
## Summary
- Nested Peridio EVK documentation under "Peridio Core Rapid Setup" section for better organization
- Added new "Desktop Deploy" landing page with Avocado OS sideloading introduction
- Included "Under Development" banner to set expectations for the Desktop Deploy guide

## Test plan
- [x] Run `npm run lint` - No errors
- [x] Run `npm run build` - Build completes successfully  
- [x] Verify navigation structure displays correctly
- [x] Check that all moved pages are still accessible

🤖 Generated with [Claude Code](https://claude.ai/code)