### PR TITLE
Add under development notices and update navigation

### DIFF
--- a/src/docs/dev-center/avocado-linux/architecture-overview.md
+++ b/src/docs/dev-center/avocado-linux/architecture-overview.md
@@ -3,8 +3,8 @@ title: Architecture Overview
 description: Understand the core architecture and design principles of Avocado OS
 ---
 
-:::info Under Construction
-This documentation is currently under development. Content and features may change as we continue to improve and expand the Avocado OS platform.
+:::caution Under Development
+This documentation is currently under active development. Content and procedures may change as we refine the Avocado OS platform.
 :::
 
 Avocado OS is a comprehensive product framework built on proven open-source technologies, designed to bridge the gap between development agility and production readiness in embedded Linux systems. Built on the Yocto Project foundation with systemd service management, btrfs for atomic updates, and overlayfs for layered system architecture, it provides a robust platform that combines data integrity with system flexibility through its sophisticated extension mechanism.

--- a/src/docs/dev-center/avocado-linux/build-provisioning.md
+++ b/src/docs/dev-center/avocado-linux/build-provisioning.md
@@ -3,8 +3,8 @@ title: Build & Provisioning
 description: Advanced build system configuration and device provisioning workflows
 ---
 
-:::info Under Construction
-This documentation is currently under development. Content and features may change as we continue to improve and expand the Avocado OS platform.
+:::caution Under Development
+This documentation is currently under active development. Content and procedures may change as we refine the Avocado OS platform.
 :::
 
 Avocado's binary distribution model uses package repositories during the build phase to create custom extensions, resulting in deterministic, immutable, and cryptographically verifiable system images. Unlike traditional approaches that rely on runtime package management, this build-time composition ensures system consistency and eliminates the unpredictability of runtime package conflicts.

--- a/src/docs/dev-center/avocado-linux/development-environment.md
+++ b/src/docs/dev-center/avocado-linux/development-environment.md
@@ -3,8 +3,8 @@ title: Development Environment
 description: Set up and configure your Avocado OS development environment for building, testing, and deploying embedded Linux systems
 ---
 
-:::info Under Construction
-This documentation is currently under development. Content and features may change as we continue to improve and expand the Avocado OS platform.
+:::caution Under Development
+This documentation is currently under active development. Content and procedures may change as we refine the Avocado OS platform.
 :::
 
 Avocado OS provides an interactive development experience that feels more like modern web development than traditional embedded Linux workflows. Developers work in containerized environments with seamless connection to target devices, enabling live code reloading and interactive debugging capabilities. This approach eliminates the traditional barriers between development and target deployment, allowing for rapid iteration and experimentation.

--- a/src/docs/dev-center/avocado-linux/introduction.md
+++ b/src/docs/dev-center/avocado-linux/introduction.md
@@ -5,6 +5,10 @@ description: The Fast Track to Production-Ready Embedded Linux
 
 # Avocado OS Overview
 
+:::caution Under Development
+This documentation is currently under active development. Content and procedures may change as we refine the Avocado OS platform.
+:::
+
 ## Rethinking Embedded Linux Development
 
 Avocado OS is a productized, production-ready Embedded Linux build system — designed to give you the flexibility of Yocto without the steep learning curve or months of bring-up.

--- a/src/docs/dev-center/avocado-linux/porting-guide.md
+++ b/src/docs/dev-center/avocado-linux/porting-guide.md
@@ -3,8 +3,8 @@ title: Porting Guide
 description: Port Avocado OS to new hardware platforms and customize for specific deployment requirements
 ---
 
-:::info Under Construction
-This documentation is currently under development. Content and features may change as we continue to improve and expand the Avocado OS platform.
+:::caution Under Development
+This documentation is currently under active development. Content and procedures may change as we refine the Avocado OS platform.
 :::
 
 Avocado's architecture supports multiple target devices with a single codebase through sophisticated hardware abstraction. The same declarative configuration can be adapted for different hardware platforms, with Avocado managing the underlying differences in toolchains and kernel configurations. This unified approach provides simplified CI/CD integration for multiple hardware targets and supports products with diverse hardware variants using a single codebase.

--- a/src/docs/dev-center/avocado-linux/security-implementation.md
+++ b/src/docs/dev-center/avocado-linux/security-implementation.md
@@ -3,8 +3,8 @@ title: Security Implementation
 description: Implement Avocado OS's comprehensive defense-in-depth security architecture from hardware root of trust to application-level protection
 ---
 
-:::info Under Construction
-This documentation is currently under development. Content and features may change as we continue to improve and expand the Avocado OS platform.
+:::caution Under Development
+This documentation is currently under active development. Content and procedures may change as we refine the Avocado OS platform.
 :::
 
 Avocado OS implements a comprehensive defense-in-depth security architecture that establishes an unbroken chain of trust from hardware through kernel and all loaded extension layers. The system provides a board-agnostic command-line interface that abstracts away complex, vendor-specific mechanisms to establish a hardware root of trust, while dm-verity provides continuous integrity verification for read-only filesystems by checking each block against a pre-computed hash tree.

--- a/src/docs/dev-center/avocado-linux/system-extensions.md
+++ b/src/docs/dev-center/avocado-linux/system-extensions.md
@@ -3,8 +3,8 @@ title: System Extensions
 description: Build, deploy, and manage modular system extensions in Avocado OS
 ---
 
-:::info Under Construction
-This documentation is currently under development. Content and features may change as we continue to improve and expand the Avocado OS platform.
+:::caution Under Development
+This documentation is currently under active development. Content and procedures may change as we refine the Avocado OS platform.
 :::
 
 Avocado OS utilizes systemd's extension mechanism to provide two distinct types of extensions that enable modular system composition. System Extensions (sysext) dynamically extend the `/usr/` and `/opt/` hierarchies with executable code and resources using overlayfs, activating automatically during boot. Configuration Extensions (confext) operate on the `/etc/` hierarchy to manage and deploy system configuration independently from system software.

--- a/src/docs/dev-center/avocado-linux/system-requirements.md
+++ b/src/docs/dev-center/avocado-linux/system-requirements.md
@@ -3,8 +3,8 @@ title: System Requirements
 description: Hardware and software requirements for running Avocado OS and the SDK.
 ---
 
-:::info Under Construction
-This documentation is currently under development. Content and features may change as we continue to improve and expand the Avocado OS platform.
+:::caution Under Development
+This documentation is currently under active development. Content and procedures may change as we refine the Avocado OS platform.
 :::
 
 Avocado OS is built on the Yocto Project foundation, chosen for its industry-standard approach and comprehensive hardware support. The system leverages Yocto to create pre-built binary packages and images, allowing users to compose complete systems without dealing with Yocto's inherent complexity. Unlike traditional approaches that rely on runtime package management, Avocado's binary distribution model uses package repositories during the build phase to create custom extensions.

--- a/src/docs/dev-center/avocado-linux/update-mechanisms.md
+++ b/src/docs/dev-center/avocado-linux/update-mechanisms.md
@@ -3,8 +3,8 @@ title: Update Mechanisms
 description: Secure over-the-air update deployment and fault-tolerant update mechanisms
 ---
 
-:::info Under Construction
-This documentation is currently under development. Content and features may change as we continue to improve and expand the Avocado OS platform.
+:::caution Under Development
+This documentation is currently under active development. Content and procedures may change as we refine the Avocado OS platform.
 :::
 
 Avocado OS implements fault-tolerant update mechanisms designed for reliability under adverse conditions. The system uses btrfs for atomic updates and integrity verification, ensuring that updates either complete successfully or roll back cleanly without leaving the system in an inconsistent state. This approach provides operational continuity even in challenging deployment environments.

--- a/src/docs/dev-center/hardware/supported-hardware.md
+++ b/src/docs/dev-center/hardware/supported-hardware.md
@@ -7,6 +7,10 @@ import './support-matrix.css';
 
 # Supported Hardware
 
+:::caution Under Development
+This documentation is currently under active development. Hardware support and feature availability may change as we continue to expand platform capabilities.
+:::
+
 Peridio supports a wide range of hardware platforms for IoT device management and OTA updates. Our platform integrates seamlessly with various processors, development boards, and production-ready systems.
 
 ## Hardware Support Matrix

--- a/src/src/components/MegaMenuNavbar/index.js
+++ b/src/src/components/MegaMenuNavbar/index.js
@@ -45,8 +45,8 @@ const MegaMenuNavbar = () => {
           items: [
             { label: 'Introduction', to: '/dev-center' },
             { label: 'Provision Device', to: '/dev-center/getting-started/provision-device' },
-            { label: 'Program Device', to: '/dev-center/getting-started/program-device' },
-            { label: 'First OTA Update', to: '/dev-center/getting-started/first-ota-update' },
+            { label: 'Hardware in the Loop', to: '/dev-center/getting-started/hardware-in-the-loop' },
+            { label: 'Desktop Deploy', to: '/dev-center/getting-started/desktop-deploy' },
           ],
         },
         {


### PR DESCRIPTION
## Summary
- Changed all Avocado OS documentation pages from "Under Construction" (blue info banners) to "Under Development" (yellow caution banners)
- Added "Under Development" notice to the hardware support matrix page
- Updated mega nav Getting Started section to match sidebar navigation exactly

## Changes
- ✅ Updated 8 Avocado OS pages to use `:::caution Under Development` instead of `:::info Under Construction`
- ✅ Added development notice to Avocado OS introduction page
- ✅ Added development notice to hardware support matrix page
- ✅ Updated mega nav to show: Introduction → Provision Device → Hardware in the Loop → Desktop Deploy
- ✅ Removed outdated "Program Device" and "First OTA Update" links from mega nav

## Test plan
- [x] Run `npm run lint` - No errors
- [x] Run `npm run build` - Build completes successfully
- [x] Verify all banner styles are yellow (caution) not blue (info)
- [x] Verify mega nav matches sidebar navigation for Getting Started
- [x] No construction emojis present in any files

🤖 Generated with [Claude Code](https://claude.ai/code)