### PR TITLE
Update documentation navigation and supported hardware page

### DIFF
--- a/src/docs/dev-center/hardware/supported-hardware.md
+++ b/src/docs/dev-center/hardware/supported-hardware.md
@@ -7,10 +7,6 @@ import './support-matrix.css';
 
 # Supported Hardware
 
-:::caution Under Development
-This documentation is currently under active development. Hardware support and feature availability may change as we continue to expand platform capabilities.
-:::
-
 Peridio supports a wide range of hardware platforms for IoT device management and OTA updates. Our platform integrates seamlessly with various processors, development boards, and production-ready systems.
 
 ## Hardware Support Matrix
@@ -20,45 +16,41 @@ Peridio supports a wide range of hardware platforms for IoT device management an
   <thead>
     <tr>
       <th>Hardware Platform</th>
-      <th>Avocado Linux</th>
-      <th>OTA Updates</th>
-      <th>Remote Access</th>
+      <th>Provisioning</th>
+      <th>HITL</th>
+      <th>Side Loading</th>
+      <th>Extension OTA</th>
+      <th>OS OTA</th>
       <th>Secure Boot</th>
-      <th>A/B Partitions</th>
-      <th>Container Updates</th>
-      <th>Fleet Management</th>
-      <th>Production Ready</th>
+      <th>Remote Access Tunnels</th>
     </tr>
   </thead>
   <tbody>
     <tr className="category-header">
-      <td colSpan="9"><strong>Production Ready Systems</strong></td>
+      <td colSpan="8"><strong>Production Ready</strong></td>
     </tr>
     <tr>
-      <td><strong>Seeed reTerminal</strong></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-    </tr>
-    <tr>
-      <td><strong>iCam540</strong></td>
-      <td><span className="status-partial" title="In Development">●</span></td>
+      <td><strong><a href="/solutions/advantech/icam-540" target="_blank" rel="noopener noreferrer">Advantech ICAM-540</a></strong></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-partial" title="In Development">●</span></td>
       <td><span className="status-partial" title="In Development">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-partial" title="In Development">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
     </tr>
     <tr>
-      <td><strong>OnLogic Factor 201/202</strong></td>
-      <td><span className="status-partial" title="In Development">●</span></td>
+      <td><strong><a href="/solutions/onlogic" target="_blank" rel="noopener noreferrer">OnLogic FR-201</a></strong></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong><a href="/solutions/seeed" target="_blank" rel="noopener noreferrer">Seeed reTerminal</a></strong></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
@@ -68,71 +60,60 @@ Peridio supports a wide range of hardware platforms for IoT device management an
       <td><span className="status-full" title="Fully Supported">●</span></td>
     </tr>
     <tr className="category-header">
-      <td colSpan="9"><strong>NVIDIA Platforms</strong></td>
+      <td colSpan="8"><strong>EVKs</strong></td>
     </tr>
     <tr>
-      <td><strong>Jetson Orin Nano EVK</strong></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><strong><a href="/dev-center/hardware/nvidia/jetson-orin-nano-evk" target="_blank" rel="noopener noreferrer">NVIDIA Jetson Orin Nano EVK</a></strong></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-partial" title="In Development">●</span></td>
+      <td><span className="status-partial" title="In Development">●</span></td>
+      <td><span className="status-partial" title="In Development">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong><a href="/dev-center/hardware/nxp/imx8mp" target="_blank" rel="noopener noreferrer">NXP i.MX 8MP EVK</a></strong></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong><a href="/dev-center/hardware/nxp/frdm-imx-93" target="_blank" rel="noopener noreferrer">NXP i.MX 93 FRDM SBC</a></strong></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong><a href="/dev-center/hardware/raspberry-pi/compute-module-4" target="_blank" rel="noopener noreferrer">Raspberry Pi 4 Compute Module</a></strong></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
+      <td><span className="status-full" title="Fully Supported">●</span></td>
     </tr>
     <tr className="category-header">
-      <td colSpan="9"><strong>NXP Platforms</strong></td>
+      <td colSpan="8"><strong>Virtual Environment</strong></td>
     </tr>
     <tr>
-      <td><strong>i.MX 93 FRDM SBC</strong></td>
+      <td><strong><a href="/dev-center/hardware/qemu" target="_blank" rel="noopener noreferrer">QEMU (Virtual Machine)</a></strong></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-partial" title="In Development">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-partial" title="In Development">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-partial" title="In Development">●</span></td>
-    </tr>
-    <tr>
-      <td><strong>i.MX 8MP EVK</strong></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-partial" title="In Development">●</span></td>
-    </tr>
-    <tr className="category-header">
-      <td colSpan="9"><strong>Raspberry Pi</strong></td>
-    </tr>
-    <tr>
-      <td><strong>Compute Module 4</strong></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-partial" title="In Development">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-none" title="Not Supported">●</span></td>
-    </tr>
-    <tr className="category-header">
-      <td colSpan="9"><strong>Virtual Platforms</strong></td>
-    </tr>
-    <tr>
-      <td><strong>QEMU (x86_64)</strong></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
       <td><span className="status-none" title="Not Applicable">●</span></td>
       <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-full" title="Fully Supported">●</span></td>
-      <td><span className="status-none" title="Not Applicable">●</span></td>
     </tr>
   </tbody>
 </table>
@@ -141,67 +122,119 @@ Peridio supports a wide range of hardware platforms for IoT device management an
 <div className="support-legend">
   <h3>Legend</h3>
   <ul>
-    <li><span className="status-full">●</span> Fully Supported - Production ready with full feature support</li>
-    <li><span className="status-partial">●</span> In Development - Feature available in beta or limited capacity</li>
-    <li><span className="status-none">●</span> Not Supported - Feature not available or not applicable</li>
+    <li><span className="status-full">●</span> Fully Supported</li>
+    <li><span className="status-partial">●</span> In Development</li>
+    <li><span className="status-none">●</span> Not Supported</li>
   </ul>
+</div>
+
+## Under Evaluation
+
+<div className="support-matrix-container">
+<table className="support-matrix">
+  <thead>
+    <tr>
+      <th>Hardware Platform</th>
+      <th>Provisioning</th>
+      <th>HITL</th>
+      <th>Side Loading</th>
+      <th>Extension OTA</th>
+      <th>OS OTA</th>
+      <th>Secure Boot</th>
+      <th>Remote Access Tunnels</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>BeagleBone AI-64</strong></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong>Intel NUC</strong></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong>NVIDIA Jetson Nano</strong></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong>Qualcomm RB5</strong></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong>Raspberry Pi 5</strong></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong>STM32MP1 Discovery Kit</strong></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+    </tr>
+    <tr>
+      <td><strong>Toradex Modules</strong></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+      <td><span className="status-none" title="Not Supported">●</span></td>
+    </tr>
+  </tbody>
+</table>
 </div>
 
 ## Feature Descriptions
 
-### Core Features
+**[Provisioning](/dev-center/getting-started/provision-device)** - Secure device onboarding and authentication setup for connecting devices to Peridio.
 
-**Avocado Linux** - Pre-configured Linux distribution optimized for embedded devices with deterministic builds and minimal footprint.
+**[HITL (Hardware in the Loop)](/dev-center/getting-started/hardware-in-the-loop)** - Real-time device testing and development support for continuous integration workflows.
 
-**OTA Updates** - Over-the-air firmware and software updates with rollback protection and delta updates.
+**[Side Loading](/dev-center/getting-started/desktop-deploy)** - Direct firmware deployment for development and debugging without network connectivity.
 
-**Remote Access** - Secure SSH tunneling and remote shell access for debugging and maintenance.
+**[Extension OTA](/dev-center/peridio-core/ota/overview)** - Over-the-air updates for applications, containers, and add-on components.
 
-**Secure Boot** - Hardware-backed secure boot chain with signature verification and chain of trust.
+**[OS OTA](/dev-center/peridio-core/ota/overview)** - Complete operating system updates with rollback protection and atomic operations.
 
-### Advanced Features
+**[Secure Boot](/dev-center/avocado-linux/security-implementation)** - Hardware-backed secure boot chain with signature verification and chain of trust.
 
-**A/B Partitions** - Dual partition scheme for safe updates with automatic rollback on failure.
+**[Remote Access Tunnels](/dev-center/tunnels/overview)** - Secure SSH tunneling for remote device management and troubleshooting.
 
-**Container Updates** - Docker and Podman container deployment and orchestration support.
+## Request Hardware Support
 
-**Fleet Management** - Centralized device monitoring, configuration, and batch operations.
-
-**Production Ready** - Certified for commercial deployment with long-term support and SLAs.
-
-## Hardware Categories
-
-### Production Ready Systems
-
-Complete, certified systems available from leading distributors that are ready for immediate deployment at scale. These systems come with full Peridio integration and are available from distributors like OnLogic, Advantech, Mouser, and others.
-
-### Development Boards
-
-Popular development platforms for prototyping and evaluation, including Raspberry Pi, NVIDIA Jetson, and NXP development kits.
-
-### Virtual Environments
-
-QEMU and other virtualization platforms for testing and development without physical hardware.
-
-## Getting Started with Hardware
-
-1. **Choose Your Platform**: Select hardware that matches your project requirements
-2. **Follow Integration Guides**: Use our detailed guides for your specific hardware
-3. **Deploy Peridio Agent**: Install and configure the Peridio agent on your device
-4. **Test OTA Updates**: Validate update functionality with your hardware
-5. **Scale Production**: Move from prototype to production deployment
-
-## Hardware Requirements
-
-Minimum requirements for Peridio integration:
-
-- Linux-based operating system (or Android)
-- Network connectivity (Ethernet, WiFi, or Cellular)
-- Sufficient storage for update staging
-- Secure boot capabilities (recommended)
-
-## Need Help?
-
-- Browse our hardware-specific guides
-- Contact our support team for integration assistance
-- Join our community forums for hardware discussions
+If you'd like Peridio to support your hardware platform, <a href="https://calendly.com/peridio/book-a-meeting" target="_blank" rel="noopener noreferrer">click here to book a meeting</a> with our team.

--- a/src/docs/dev-center/integration/index.md
+++ b/src/docs/dev-center/integration/index.md
@@ -1,8 +1,8 @@
 ---
-title: 🚧 Integration / Guides
+title: Integration & Guides
 ---
 
-# 🚧 Integration / Guides
+# Integration & Guides
 
 This section provides comprehensive guides for integrating various Peridio features and services into your IoT infrastructure. Learn how to implement webhooks, configure external CDNs, manage certificates, and deploy the Peridio agent.
 

--- a/src/sidebars.js
+++ b/src/sidebars.js
@@ -5,7 +5,7 @@ export default {
   platform: [
     {
       type: 'doc',
-      label: 'Getting started',
+      label: 'Getting Started',
       id: 'platform/getting-started',
     },
     {
@@ -17,7 +17,7 @@ export default {
         'platform/reference/overview',
         {
           type: 'category',
-          label: 'Account management',
+          label: 'Account Management',
           items: [
             'platform/reference/organizations',
             'platform/reference/peridio-resource-names',
@@ -26,7 +26,7 @@ export default {
         },
         {
           type: 'category',
-          label: 'Binary management',
+          label: 'Binary Management',
           items: [
             {
               type: 'doc',
@@ -58,7 +58,7 @@ export default {
         },
         {
           type: 'category',
-          label: 'Device management',
+          label: 'Device Management',
           items: [
             {
               type: 'doc',
@@ -82,12 +82,12 @@ export default {
         },
         {
           type: 'category',
-          label: 'Integration management',
+          label: 'Integration Management',
           items: ['platform/reference/webhooks'],
         },
         {
           type: 'category',
-          label: 'Bundle mangement',
+          label: 'Bundle Management',
           items: [
             {
               type: 'doc',
@@ -101,24 +101,24 @@ export default {
             },
             {
               type: 'doc',
-              label: 'Release channels',
+              label: 'Release Channels',
               id: 'platform/reference/release-channels',
             },
             {
               type: 'doc',
-              label: 'Bundle overrides',
+              label: 'Bundle Overrides',
               id: 'platform/reference/bundle-overrides',
             },
             {
               type: 'doc',
-              label: 'Bundle distribution',
+              label: 'Bundle Distribution',
               id: 'platform/reference/bundle-distribution',
             },
           ],
         },
         {
           type: 'category',
-          label: 'Remote access',
+          label: 'Remote Access',
           items: ['platform/reference/tunnels'],
         },
         {
@@ -158,12 +158,12 @@ export default {
       items: [
         {
           type: 'category',
-          label: 'Cloud integration',
+          label: 'Cloud Integration',
           items: ['platform/guides/cloud-delegated-updates'],
         },
         {
           type: 'category',
-          label: 'Binary management',
+          label: 'Binary Management',
           items: [
             'platform/guides/introduction-to-binary-management',
             'platform/guides/multipart-uploads-with-binary-parts',
@@ -178,7 +178,7 @@ export default {
         },
         {
           type: 'category',
-          label: 'Device management',
+          label: 'Device Management',
           items: [
             'platform/guides/creating-ca-certificates',
             'platform/guides/creating-devices',
@@ -189,7 +189,7 @@ export default {
         },
         {
           type: 'category',
-          label: 'Bundle management',
+          label: 'Bundle Management',
           items: [
             'platform/guides/introduction-to-bundle-management',
             'platform/guides/creating-bundles',
@@ -198,7 +198,7 @@ export default {
         },
         {
           type: 'category',
-          label: 'Remote access',
+          label: 'Remote Access',
           items: [
             'platform/guides/introduction-to-remote-access',
             'platform/guides/creating-tunnels',
@@ -389,6 +389,29 @@ export default {
       items: [
         {
           type: 'category',
+          label: 'EVKs',
+          items: [
+            {
+              type: 'doc',
+              id: 'dev-center/hardware/nvidia/jetson-orin-nano-evk',
+              label: 'NVIDIA Jetson Orin Nano EVK',
+            },
+            { type: 'doc', id: 'dev-center/hardware/nxp/imx8mp', label: 'NXP i.MX 8MP EVK' },
+            {
+              type: 'doc',
+              id: 'dev-center/hardware/nxp/frdm-imx-93',
+              label: 'NXP i.MX 93 FRDM SBC',
+            },
+            { type: 'doc', id: 'dev-center/hardware/qemu', label: 'QEMU (Virtual Machine)' },
+            {
+              type: 'doc',
+              id: 'dev-center/hardware/raspberry-pi/compute-module-4',
+              label: 'Raspberry Pi Compute Module 4',
+            },
+          ],
+        },
+        {
+          type: 'category',
           label: 'Production Ready',
           link: {
             type: 'doc',
@@ -397,41 +420,23 @@ export default {
           items: [
             {
               type: 'html',
-              value: '<a href="/solutions/seeed" target="_blank" rel="noopener noreferrer" class="menu__link" style="display: block;">Seeed reTerminal</a>',
-            },
-            {
-              type: 'html',
               value: '<a href="/solutions/advantech/icam-540" target="_blank" rel="noopener noreferrer" class="menu__link" style="display: block;">Advantech ICAM-540</a>',
             },
             {
               type: 'html',
               value: '<a href="/solutions/onlogic" target="_blank" rel="noopener noreferrer" class="menu__link" style="display: block;">OnLogic FR201</a>',
             },
+            {
+              type: 'html',
+              value: '<a href="/solutions/seeed" target="_blank" rel="noopener noreferrer" class="menu__link" style="display: block;">Seeed reTerminal</a>',
+            },
           ],
         },
-        {
-          type: 'doc',
-          id: 'dev-center/hardware/nvidia/jetson-orin-nano-evk',
-          label: 'NVIDIA Jetson Orin Nano EVK',
-        },
-        {
-          type: 'doc',
-          id: 'dev-center/hardware/nxp/frdm-imx-93',
-          label: 'NXP i.MX 93 FRDM SBC',
-        },
-        { type: 'doc', id: 'dev-center/hardware/nxp/imx8mp', label: 'NXP i.MX 8MP EVK' },
-        {
-          type: 'doc',
-          id: 'dev-center/hardware/raspberry-pi/compute-module-4',
-          label: 'Raspberry Pi Compute Module 4',
-        },
-        { type: 'doc', id: 'dev-center/hardware/qemu', label: 'QEMU (Virtual Machine)' },
-        { type: 'doc', id: 'dev-center/hardware/coming-soon', label: '🚀 Coming Soon' },
       ],
     },
     {
       type: 'category',
-      label: 'Integration / Guides',
+      label: 'Integration & Guides',
       link: {
         type: 'doc',
         id: 'dev-center/integration/index',


### PR DESCRIPTION
## Summary
- Cleaned up navigation menu items and improved consistency
- Updated Supported Hardware page with new structure and features
- Implemented all requirements from vibe/cleanup.md

## Changes

### Navigation Updates
- Removed construction emoji (🚧) from Integration/Guides
- Renamed "Integration / Guides" to "Integration & Guides"
- Fixed capitalization consistency across all menu items (Account Management, Binary Management, etc.)
- Removed "Coming Soon" section from Supported Hardware navigation
- Reorganized hardware into EVKs and Production Ready categories (alphabetized)

### Supported Hardware Page
- Removed "Under Development" caution block
- Updated matrix columns to match landing page features:
  - Provisioning, HITL, Side Loading, Extension OTA, OS OTA, Secure Boot, Remote Access Tunnels
- Created two main sections: EVKs and Production Ready
- Added "Under Evaluation" table for future hardware (all marked as not supported)
- Simplified legend (removed descriptions)
- Added feature descriptions with documentation links
- Added call-to-action for hardware support requests with booking link
- Set correct support levels per requirements:
  - NXP i.MX 8MP, NXP FRDM 93, Raspberry Pi 4 CM, Seeed reTerminal, OnLogic FR-201: All green
  - NVIDIA Jetson & Advantech ICAM-540: Green for Provisioning, HITL, Side Loading, Remote Access; In Development for others

## Test Plan
- [x] Run `npm run lint` - No errors (only warnings)
- [x] Run `npm run build` - Builds successfully
- [x] Verify all navigation links work
- [x] Confirm hardware matrix displays correctly
- [x] Check all documentation links resolve properly

🤖 Generated with [Claude Code](https://claude.ai/code)