### PR TITLE
Fix: Update homepage content and links

### DIFF
--- a/src/src/pages/index.js
+++ b/src/src/pages/index.js
@@ -140,12 +140,13 @@ export default function Home() {
           </div>
           <div className={styles.body}>
             <p className={styles.description}>
-              A secure, updatable Linux distribution built for embedded devices. Get to production
-              faster with pre-configured security, OTA updates, and container support.
+              Simplified Embedded Linux. With day-one BSPs for leading hardware targets, a fully 
+              open-source foundation, and built-in extensibility, Avocado OS lets your team focus 
+              on building applications — not wrestling with the OS.
             </p>
             {/* Avocado OS Links Section */}
             <div className={styles.linkGrid}>
-              <Link to="/dev-center/avocado-linux/introduction" className={styles.externalLink}>
+              <Link to="/dev-center" className={styles.externalLink}>
                 <svg
                   width="16"
                   height="16"
@@ -182,8 +183,8 @@ export default function Home() {
                 </svg>
                 Get Involved
               </Link>
-              <Link
-                to="https://discord.com/invite/rH77fKpKAj"
+              <a
+                href="https://www.peridio.com/join-our-discord"
                 className={styles.externalLink}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -202,7 +203,7 @@ export default function Home() {
                   />
                 </svg>
                 Join Discord
-              </Link>
+              </a>
               <Link
                 to="https://avocadolinux.org"
                 className={styles.externalLink}


### PR DESCRIPTION
## Summary
- Updated Discord link to use official Peridio redirect URL
- Refreshed Avocado OS description to emphasize simplified embedded Linux
- Updated Avocado OS navigation to point to dev-center

## Changes
1. **Discord Link**: Changed from direct Discord invite to `https://www.peridio.com/join-our-discord`
2. **Avocado OS Description**: Removed container mention and updated copy to focus on day-one BSPs and application development  
3. **Avocado OS Navigation**: Changed "Get Started" link from `/dev-center/avocado-linux/introduction` to `/dev-center`

## Test plan
- [x] Verified lint passes (warnings only, no errors)
- [x] Verified build completes successfully
- [ ] Test Discord link redirects properly
- [ ] Verify Avocado OS link navigates to dev-center

🤖 Generated with [Claude Code](https://claude.ai/code)