### PR TITLE
Fix: Correct FR201 temperature range specifications

### DIFF
--- a/src/src/pages/solutions/onlogic/content.md
+++ b/src/src/pages/solutions/onlogic/content.md
@@ -7,7 +7,7 @@ Transform your OnLogic FR201 from development platform to production gateway wit
 ### Key Stats
 
 - **Fanless** - Silent Operation
-- **-40°C to +70°C** - Wide Temperature Range
+- **-20°C to +60°C** - Wide Temperature Range
 - **24/7** - Continuous Operation
 - **6x Faster** - Time to Production
 

--- a/src/src/pages/solutions/onlogic/index.js
+++ b/src/src/pages/solutions/onlogic/index.js
@@ -17,7 +17,7 @@ const solutionData = {
       'Transform your OnLogic FR201 from development platform to production gateway with enterprise-grade Linux deployment',
     stats: [
       { value: 'Fanless', label: 'Silent Operation' },
-      { value: '-40°C to +70°C', label: 'Wide Temperature Range' },
+      { value: '-20°C to +60°C', label: 'Wide Temperature Range' },
       { value: '6x Faster', label: 'Time to Production' },
     ],
     primaryCTA: {


### PR DESCRIPTION
## Summary
- Corrected OnLogic FR201 operating temperature range from -40°C to +70°C to the accurate -20°C to +60°C
- Updated both the solution landing page and content markdown file

## Test plan
- [x] Ran `npm run lint` - no errors
- [x] Ran `npm run build` - build successful
- [x] Verified temperature range displays correctly on the FR201 solution page

🤖 Generated with [Claude Code](https://claude.ai/code)