### PR TITLE
Update Avocado OS link and label on homepage

### DIFF
--- a/src/src/pages/index.js
+++ b/src/src/pages/index.js
@@ -166,7 +166,7 @@ export default function Home() {
               </p>
               {/* Avocado OS Links Section */}
               <div className={styles.linkGrid}>
-                <Link to="/" className={styles.externalLink}>
+                <Link to="/avocado-linux/introduction" className={styles.externalLink}>
                   <svg
                     width="16"
                     height="16"
@@ -175,11 +175,11 @@ export default function Home() {
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"
+                      d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z"
                       fill="currentColor"
                     />
                   </svg>
-                  Get Started
+                  Overview
                 </Link>
                 <Link
                   to="https://github.com/avocado-linux"


### PR DESCRIPTION
- Updated the empty "get started" Avocado OS link destination from '/' to '/avocado-linux/introduction'
- updated the SVG icon, and changed the link label from 'Get Started' to 'Overview' to match the styling of the peridio core card