### PR TITLE
Update RPi 5 image in carousel

### DIFF
--- a/src/src/components/HardwareCarousel/index.js
+++ b/src/src/components/HardwareCarousel/index.js
@@ -14,7 +14,7 @@ const slides = [
   {
     vendor: 'Raspberry Pi',
     target: 'Raspberry Pi 5',
-    image: '/img/raspberry-pi.jpg',
+    image: '/img/raspberrypi-5.jpg',
     overviewLink: '/solutions/raspberry-pi/raspberry-pi-5',
     getStartedLink: '/avocado-linux/guides/getting-started',
   },


### PR DESCRIPTION
Changed the image path for the Raspberry Pi 5 slide to use '/img/raspberrypi-5.jpg' instead of '/img/raspberry-pi.jpg' for improved accuracy.