### PR TITLE
docs: avocado-cli 0.35.0 and 0.36.0 release notes and updated reference

### DIFF
--- a/src/docs-changelog/april-2026/0.35.0.md
+++ b/src/docs-changelog/april-2026/0.35.0.md
@@ -31,7 +31,7 @@ runtimes:
 
 Subvolume config participates in the rebuild input hash, so adding, removing, or changing a subvolume triggers a proper rebuild of the var image. Short forms (`true`, `false`, `"ro"`) are supported alongside the full object form, and conflict detection emits warnings for exact-path collisions between extensions and for nested subvolume paths that would leak quota isolation.
 
-See [Var partition configuration](/guides/avocado-cli/configuration#var-partition-configuration) for the full option reference.
+See [Var partition configuration](/developer-reference/avocado-cli/configuration#var-partition-configuration) for the full option reference.
 
 ### `avocado connect clean`
 

--- a/src/docs-changelog/april-2026/0.35.0.md
+++ b/src/docs-changelog/april-2026/0.35.0.md
@@ -1,0 +1,62 @@
+---
+title: '0.35.0'
+description: 'Avocado CLI 0.35.0 release notes.'
+---
+
+## New features
+
+### Btrfs subvolumes for var partitions
+
+Runtime `var` partitions can now declare btrfs subvolumes with per-path options for compression, quotas, NOCOW, and read-only state. Subvolumes may be declared at the extension level (where they travel with the extension) or at the runtime level (where they override extension-declared values).
+
+```yaml
+extensions:
+  my-ext:
+    subvolumes:
+      lib/docker:
+        nodatacow: true
+        quota: '10G'
+      lib/myapp/cache: true
+
+runtimes:
+  dev:
+    extensions: [my-ext]
+    var:
+      compression: 'zstd:3' # partition-wide default
+      subvolumes:
+        lib/docker:
+          writable: false # override: make it read-only
+        lib/avocado: true # built-in, declared here to suppress warnings
+```
+
+Subvolume config participates in the rebuild input hash, so adding, removing, or changing a subvolume triggers a proper rebuild of the var image. Short forms (`true`, `false`, `"ro"`) are supported alongside the full object form, and conflict detection emits warnings for exact-path collisions between extensions and for nested subvolume paths that would leak quota isolation.
+
+See [Var partition configuration](/guides/avocado-cli/configuration#var-partition-configuration) for the full option reference.
+
+### `avocado connect clean`
+
+Removes Connect configuration from a project: strips the `connect:` section and `avocado-ext-connect-config` extension from `avocado.yaml`, and deletes the `overlay/etc/avocado-conn/` directory. Useful when disconnecting a project from the Connect platform or resetting state for a fresh `avocado connect init`.
+
+```bash
+avocado connect clean           # clean dev runtime (default)
+avocado connect clean -r prod   # clean a specific runtime
+```
+
+### SDK version locking per host architecture
+
+SDK package lock files now store full NEVRA versions per host architecture instead of stripping the `.ARCH` suffix. This gives exact package pinning per host arch and removes a reproducibility gap where `x86-64` and `aarch64` hosts could resolve to slightly different SDK packages from the same lock file.
+
+---
+
+## Bug fixes
+
+- Subvolumes are now created as read-write at `mkfs.btrfs` time and flipped to read-only after properties are applied via loop mount, since `btrfs property set` rejects read-only subvolumes.
+- Compression is skipped on `nodatacow` subvolumes — NOCOW and transparent compression are mutually exclusive on btrfs (COW is required for compression).
+- Replaced the unsupported `mkfs.btrfs --inode-flags` flag with `--compress` at image creation time plus post-creation loop mount (`chattr +C` for NOCOW, `btrfs property set` for per-subvolume compression and quotas).
+
+---
+
+## Other
+
+- `avocado init --reference` now resolves references against the standalone `avocado-linux/references` repository instead of `avocado-linux/avocado-os/references/`.
+- Per-property echo output during subvolume post-creation setup makes the build log transparent about which properties (nodatacow, compression, quota, read-only) are being applied to which path.

--- a/src/docs-changelog/april-2026/0.36.0.md
+++ b/src/docs-changelog/april-2026/0.36.0.md
@@ -67,7 +67,7 @@ Resolution order: CLI `-r`/`--runtime` > `AVOCADO_RUNTIME` env var > `default_ru
 
 The `AVOCADO_RUNTIME` environment variable mirrors this at the shell level and takes precedence over the config value.
 
-See [Default runtime](/guides/avocado-cli/configuration#default-runtime) for details.
+See [Default runtime](/developer-reference/avocado-cli/configuration#default-runtime) for details.
 
 ### Overlay support for rootfs and initramfs
 

--- a/src/docs-changelog/april-2026/0.36.0.md
+++ b/src/docs-changelog/april-2026/0.36.0.md
@@ -85,7 +85,7 @@ initramfs:
 
 Merge mode (default) uses `rsync -a` — adds and replaces files but leaves unrelated files alone. Opaque mode uses `cp -r` — fully replaces the directory. Overlay config participates in the sysroot stamp hash, so changes trigger a reinstall.
 
-See [Overlay](/guides/avocado-cli/configuration#overlay) for details.
+See [Overlay](/developer-reference/avocado-cli/configuration#overlay) for details.
 
 ---
 

--- a/src/docs-changelog/april-2026/0.36.0.md
+++ b/src/docs-changelog/april-2026/0.36.0.md
@@ -1,0 +1,109 @@
+---
+title: '0.36.0'
+description: 'Avocado CLI 0.36.0 release notes.'
+---
+
+## New features
+
+### Kernel version pinning and resolution
+
+Avocado projects can now declare one or more named kernel configurations at the top level and reference them per-runtime. The `kernel:` block accepts either a singleton (synthesized as the implicit `default` entry) or a named map:
+
+```yaml
+kernel:
+  yocto-6-6:
+    package: kernel-image-6.6
+    version: '*'
+  yocto-5-15:
+    package: kernel-image-5.15
+    version: '*'
+
+runtimes:
+  dev:
+    kernel: yocto-6-6 # named reference
+  prod:
+    kernel: # inline override
+      package: kernel-image
+      version: '6.6.*'
+```
+
+Kernels may also be sourced from a compile section instead of a package feed (for custom Yocto or out-of-tree kernels):
+
+```yaml
+kernel:
+  custom:
+    compile: my-kernel-section
+    install: scripts/install-kernel.sh
+```
+
+`provision` and `deploy` now validate kernel consistency across sysroots before writing to the device or flashing. If the kernel installed in rootfs diverges from the kernel sysroot, the CLI will report the drift and abort.
+
+See [Kernel configuration](/guides/avocado-cli/configuration#kernel-configuration) for the full option reference.
+
+### Runtime-scoped extensions and `AVOCADO_RUNTIME`
+
+Extension lifecycle commands (`ext build`, `ext clean`, `ext image`, `ext dnf`, `ext checkout`, `ext package`) now accept a `-r`/`--runtime` flag. When a runtime is provided, the command operates on the per-runtime extension sysroot instead of the shared per-target tree, and the `AVOCADO_RUNTIME` environment variable is forwarded into the container so that `$AVOCADO_EXT_SYSROOTS` is scoped to the correct runtime directory.
+
+```bash
+avocado ext build my-ext -r prod
+AVOCADO_RUNTIME=prod avocado ext build my-ext
+```
+
+Runtime membership is now recorded in the lockfile (lockfile v6), so extension state is tracked per-runtime rather than globally. `runtime build` propagates `AVOCADO_RUNTIME` to all sub-container invocations automatically.
+
+### `default_runtime` config option
+
+A new top-level `default_runtime` field sets the project-wide default runtime for commands that scope by runtime. This avoids passing `-r` on every invocation:
+
+```yaml
+default_runtime: dev
+
+runtimes:
+  dev: { ... }
+  prod: { ... }
+```
+
+Resolution order: CLI `-r`/`--runtime` > `AVOCADO_RUNTIME` env var > `default_runtime` config > auto-resolved sole runtime.
+
+The `AVOCADO_RUNTIME` environment variable mirrors this at the shell level and takes precedence over the config value.
+
+See [Default runtime](/guides/avocado-cli/configuration#default-runtime) for details.
+
+### Overlay support for rootfs and initramfs
+
+Rootfs and initramfs configs now accept an `overlay` field that merges a source directory from your project into the sysroot after package installation:
+
+```yaml
+rootfs:
+  overlay: overlays/rootfs # short form: merge mode
+
+initramfs:
+  overlay:
+    dir: overlays/initramfs
+    mode: opaque # fully replaces directory contents
+```
+
+Merge mode (default) uses `rsync -a` — adds and replaces files but leaves unrelated files alone. Opaque mode uses `cp -r` — fully replaces the directory. Overlay config participates in the sysroot stamp hash, so changes trigger a reinstall.
+
+See [Overlay](/guides/avocado-cli/configuration#overlay) for details.
+
+---
+
+## Bug fixes
+
+- `deploy` now validates the runtime build stamp (not the provision stamp) before flashing, preventing stale images from being deployed.
+- Rootfs and initramfs stamps now include kernel config in their input hash — changing a kernel pin invalidates the sysroot and triggers a clean reinstall.
+- When a lockfile kernel pin no longer satisfies the configured version spec, the kernel is re-resolved and the sysroot is reinstalled rather than silently using an out-of-spec kernel.
+- On kernel pin change, rootfs and initramfs are cleaned and reinstalled so all kernel modules match the new kernel.
+- Lockfile saves are now serialized through a process-wide gate with a disk-merge step, preventing concurrent readers from seeing truncated (EOF) state.
+- Extension lockfile entries written during `ext install` now persist even when the extension has zero packages (membership is tracked independently of package count).
+- Runtime extension package maps are now merged at the package-map level on lockfile load, not at the whole-lock level, preventing cross-runtime package contamination.
+- `query_installed_packages` forwards `env_vars` into the container so that runtime-scoped DNF queries resolve the correct sysroot.
+
+---
+
+## Other
+
+- Lockfile schema bumped to v6: extensions are now tracked under `targets.<t>.runtimes.<r>.extensions` instead of a flat global map. The CLI migrates v5 lockfiles automatically on first write.
+- Lockfile writes use atomic rename so concurrent readers never observe a partial file.
+- Dependency updates: `crossterm` 0.28 → 0.29, `serde_jcs` 0.1 → 0.2, `sha2` 0.10 → 0.11, `tough` 0.21 → 0.22.

--- a/src/docs-changelog/april-2026/0.36.0.md
+++ b/src/docs-changelog/april-2026/0.36.0.md
@@ -38,7 +38,7 @@ kernel:
 
 `provision` and `deploy` now validate kernel consistency across sysroots before writing to the device or flashing. If the kernel installed in rootfs diverges from the kernel sysroot, the CLI will report the drift and abort.
 
-See [Kernel configuration](/guides/avocado-cli/configuration#kernel-configuration) for the full option reference.
+See [Kernel configuration](/developer-reference/avocado-cli/configuration#kernel-configuration) for the full option reference.
 
 ### Runtime-scoped extensions and `AVOCADO_RUNTIME`
 

--- a/src/docs-changelog/index.mdx
+++ b/src/docs-changelog/index.mdx
@@ -4,4 +4,4 @@ title: 'Changelog'
 
 import { Redirect } from '@docusaurus/router'
 
-<Redirect to="/changelog/april-2026/0.34.0" />
+<Redirect to="/changelog/april-2026/0.36.0" />

--- a/src/docs-guides/avocado-cli/commands.md
+++ b/src/docs-guides/avocado-cli/commands.md
@@ -488,6 +488,28 @@ Options:
 
 ---
 
+### `avocado connect clean`
+
+```
+Remove connect configuration (connect section, connect-config extension, and device config overlay)
+
+Usage: avocado connect clean [OPTIONS]
+
+Options:
+  -r, --runtime <RUNTIME>    Runtime to remove connect-config extension from (default: dev) [default: dev]
+  -C, --config <CONFIG>      Path to avocado.yaml configuration file [default: avocado.yaml]
+      --runs-on <USER@HOST>  Run command on remote host using local volume via NFS (format: user@host)
+      --nfs-port <NFS_PORT>  NFS port for remote execution (auto-selects from 12050-12099 if not specified)
+      --sdk-arch <ARCH>      SDK container architecture for cross-arch emulation via Docker buildx/QEMU (aarch64 or x86-64)
+      --no-tui               Disable TUI output (use legacy sequential output with inherited stdio)
+  -h, --help                 Print help
+
+```
+
+Removes Connect state from the project: strips the `connect:` section and the `avocado-ext-connect-config` extension from `avocado.yaml`, and deletes `overlay/etc/avocado-conn/`. Operations are idempotent — missing items are skipped with an info message.
+
+---
+
 ### `avocado connect deploy`
 
 ```
@@ -1114,6 +1136,7 @@ Options:
   -C, --config <CONFIG>                 Path to avocado.yaml configuration file [default: avocado.yaml]
   -v, --verbose                         Enable verbose output
   -t, --target <TARGET>                 Target architecture
+  -r, --runtime <RUNTIME>               Runtime to build the extension against (kernel/rootfs context). Resolves from AVOCADO_RUNTIME / default_runtime / sole-runtime when omitted
       --container-arg <CONTAINER_ARGS>  Additional arguments to pass to the container runtime
       --dnf-arg <DNF_ARGS>              Additional arguments to pass to DNF commands
       --runs-on <USER@HOST>             Run command on remote host using local volume via NFS (format: user@host)
@@ -1147,6 +1170,8 @@ Options:
           Path within the extension sysroot to checkout (e.g., /etc/config.json or /etc for directory)
       --src-path <SRC_PATH>
           Destination path in source directory (relative to src root)
+  -r, --runtime <RUNTIME>
+          Runtime context for the checkout (selects which sysroot tree the files come from)
       --container-tool <CONTAINER_TOOL>
           Container tool to use (docker/podman) [default: docker]
       --runs-on <USER@HOST>
@@ -1178,6 +1203,7 @@ Options:
   -C, --config <CONFIG>                 Path to avocado.yaml configuration file [default: avocado.yaml]
   -v, --verbose                         Enable verbose output
   -t, --target <TARGET>                 Target architecture
+  -r, --runtime <RUNTIME>               Runtime context for the clean. Falls through to per-target behavior when no runtime resolves
       --container-arg <CONTAINER_ARGS>  Additional arguments to pass to the container runtime
       --dnf-arg <DNF_ARGS>              Additional arguments to pass to DNF commands
       --runs-on <USER@HOST>             Run command on remote host using local volume via NFS (format: user@host)
@@ -1228,6 +1254,7 @@ Options:
   -v, --verbose                         Enable verbose output
   -e, --extension <EXTENSION>           Name of the extension to operate on
   -t, --target <TARGET>                 Target architecture
+  -r, --runtime <RUNTIME>               Runtime context for the dnf operation (scopes which extension sysroot tree dnf operates on)
       --container-arg <CONTAINER_ARGS>  Additional arguments to pass to the container runtime
       --dnf-arg <DNF_ARGS>              Additional arguments to pass to DNF commands
       --runs-on <USER@HOST>             Run command on remote host using local volume via NFS (format: user@host)
@@ -1280,6 +1307,7 @@ Options:
   -C, --config <CONFIG>                 Path to avocado.yaml configuration file [default: avocado.yaml]
   -v, --verbose                         Enable verbose output
   -t, --target <TARGET>                 Target architecture
+  -r, --runtime <RUNTIME>               Runtime to image the extension under (kernel/rootfs context). Same resolution rules as ext build -r
       --out <OUT_DIR>                   Output directory on host to copy the resulting image to
       --container-arg <CONTAINER_ARGS>  Additional arguments to pass to the container runtime
       --dnf-arg <DNF_ARGS>              Additional arguments to pass to DNF commands
@@ -1354,6 +1382,7 @@ Options:
   -C, --config <CONFIG>                 Path to avocado.yaml configuration file [default: avocado.yaml]
   -v, --verbose                         Enable verbose output
   -t, --target <TARGET>                 Target architecture
+  -r, --runtime <RUNTIME>               Runtime context for the package operation
       --out-dir <OUTPUT_DIR>            Output directory on host for the RPM package (relative or absolute path). If not specified, RPM stays in container at $AVOCADO_PREFIX/output/extensions
       --container-arg <CONTAINER_ARGS>  Additional arguments to pass to the container runtime
       --dnf-arg <DNF_ARGS>              Additional arguments to pass to DNF commands

--- a/src/docs-guides/avocado-cli/configuration.md
+++ b/src/docs-guides/avocado-cli/configuration.md
@@ -26,13 +26,14 @@ For detailed information about all available configuration options, see the [con
 
 Environment variables take precedence over configuration file values. When set, they override the corresponding config field.
 
-| Environment variable     | Config equivalent        | Description                                              |
-| ------------------------ | ------------------------ | -------------------------------------------------------- |
-| `AVOCADO_TARGET`         | `default_target`         | Target architecture for builds and deployments.          |
-| `AVOCADO_REPO_URL`       | `distro.repo.url`        | Package repository URL.                                  |
-| `AVOCADO_RELEASEVER`     | `distro.repo.releasever` | DNF releasever override (e.g., `2024/edge`).             |
-| `AVOCADO_DISTRO_RELEASE` | `distro.release`         | Distribution feed year (e.g., `2024`).                   |
-| `AVOCADO_DISTRO_CHANNEL` | `distro.channel`         | Distribution stability channel (e.g., `edge`, `stable`). |
+| Environment variable     | Config equivalent        | Description                                                                                  |
+| ------------------------ | ------------------------ | -------------------------------------------------------------------------------------------- |
+| `AVOCADO_TARGET`         | `default_target`         | Target architecture for builds and deployments.                                              |
+| `AVOCADO_RUNTIME`        | `default_runtime`        | Default runtime for commands that scope by runtime. Overrides `default_runtime` from config. |
+| `AVOCADO_REPO_URL`       | `distro.repo.url`        | Package repository URL.                                                                      |
+| `AVOCADO_RELEASEVER`     | `distro.repo.releasever` | DNF releasever override (e.g., `2024/edge`).                                                 |
+| `AVOCADO_DISTRO_RELEASE` | `distro.release`         | Distribution feed year (e.g., `2024`).                                                       |
+| `AVOCADO_DISTRO_CHANNEL` | `distro.channel`         | Distribution stability channel (e.g., `edge`, `stable`).                                     |
 
 ### Legacy environment variables
 
@@ -42,6 +43,27 @@ The following environment variables are deprecated but still supported as fallba
 | -------------------------- | -------------------- |
 | `AVOCADO_SDK_REPO_URL`     | `AVOCADO_REPO_URL`   |
 | `AVOCADO_SDK_REPO_RELEASE` | `AVOCADO_RELEASEVER` |
+
+## Default runtime
+
+Set `default_runtime` to avoid passing `--runtime` on every invocation. Resolution order from highest to lowest precedence:
+
+1. CLI `-r`/`--runtime` argument
+2. `AVOCADO_RUNTIME` environment variable
+3. `default_runtime` config value
+4. Auto-resolved sole runtime (when exactly one runtime is defined)
+
+```yaml
+default_runtime: dev
+
+runtimes:
+  dev:
+    # ...
+  prod:
+    # ...
+```
+
+When `default_runtime` is set, the CLI validates at startup that it references a runtime defined in `runtimes:`.
 
 ## Connect configuration
 
@@ -67,14 +89,16 @@ The `rootfs` section configures the shared rootfs sysroot used by runtime builds
 ```yaml
 rootfs:
   filesystem: erofs-lz4 # default
+  overlay: overlays/rootfs # optional: merged into sysroot after package install
   packages:
     avocado-pkg-rootfs: '*'
 ```
 
-| Field        | Default     | Description                                 |
-| ------------ | ----------- | ------------------------------------------- |
-| `filesystem` | `erofs-lz4` | Image format: `erofs-lz4` or `erofs-zst`    |
-| `packages`   |             | Map of package names to version constraints |
+| Field        | Default     | Description                                    |
+| ------------ | ----------- | ---------------------------------------------- |
+| `filesystem` | `erofs-lz4` | Image format: `erofs-lz4` or `erofs-zst`       |
+| `overlay`    |             | Path or object — see [Overlay](#overlay) below |
+| `packages`   |             | Map of package names to version constraints    |
 
 ## Initramfs configuration
 
@@ -83,6 +107,7 @@ The `initramfs` section configures the initramfs sysroot used for the early boot
 ```yaml
 initramfs:
   filesystem: cpio.zst # default
+  overlay: overlays/initramfs # optional: merged into sysroot after package install
   packages:
     avocado-pkg-initramfs: '*'
 ```
@@ -90,7 +115,152 @@ initramfs:
 | Field        | Default    | Description                                                |
 | ------------ | ---------- | ---------------------------------------------------------- |
 | `filesystem` | `cpio.zst` | Image format: `cpio`, `cpio.zst`, `cpio.lz4`, or `cpio.gz` |
+| `overlay`    |            | Path or object — see [Overlay](#overlay) below             |
 | `packages`   |            | Map of package names to version constraints                |
+
+## Overlay
+
+The `overlay` field on `rootfs` and `initramfs` merges a source directory from your project into the sysroot after package installation. Two forms are supported:
+
+```yaml
+# Short form — merge mode (rsync -a: adds/replaces files, leaves unrelated files alone)
+rootfs:
+  overlay: overlays/rootfs
+
+# Long form — explicit mode
+initramfs:
+  overlay:
+    dir: overlays/initramfs
+    mode: opaque # cp -r: fully replaces directory contents
+```
+
+| Field  | Default    | Description                                               |
+| ------ | ---------- | --------------------------------------------------------- |
+| `dir`  | (required) | Path relative to project root (`src_dir`)                 |
+| `mode` | `merge`    | `merge` (rsync -a) or `opaque` (cp -r, replaces contents) |
+
+The string short form is equivalent to `{ dir: "...", mode: "merge" }`. The overlay path is resolved as `/opt/src/<path>` inside the SDK container. Overlay config participates in the sysroot stamp, so changes trigger a reinstall.
+
+## Kernel configuration
+
+The top-level `kernel:` block defines one or more kernel configurations that runtimes can reference. Two forms are accepted:
+
+```yaml
+# Singleton form — synthesized as the implicit "default" kernel
+kernel:
+  package: kernel-image
+  version: '*'
+
+# Named map form — multiple kernels for different runtimes
+kernel:
+  yocto-6-6:
+    package: kernel-image-6.6
+    version: '*'
+  yocto-5-15:
+    package: kernel-image-5.15
+    version: '*'
+```
+
+### Kernel config fields
+
+Two mutually exclusive modes:
+
+**Package mode** — kernel installed from an RPM during `runtime install`:
+
+| Field     | Description                                                           |
+| --------- | --------------------------------------------------------------------- |
+| `package` | Package name (e.g. `kernel-image`). Mutually exclusive with `compile` |
+| `version` | Version constraint (e.g. `*`, `6.6.*`). Used with `package`           |
+
+**Compile mode** — kernel cross-compiled via `sdk.compile.<section>` during `runtime build`:
+
+| Field     | Description                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------------- |
+| `compile` | SDK compile section name (references `sdk.compile.<section>`). Mutually exclusive with `package`   |
+| `install` | Install script path — copies kernel artifacts to runtime build dir. Required when `compile` is set |
+
+### Runtime kernel references
+
+A runtime can reference a named top-level kernel entry or provide an inline override:
+
+```yaml
+runtimes:
+  dev:
+    kernel: yocto-6-6 # named reference (string)
+
+  prod:
+    kernel: # inline override (object)
+      package: kernel-image
+      version: '6.6.*'
+```
+
+When `kernel:` is omitted on a runtime, the CLI falls back to the top-level `default` kernel entry, or — when no top-level kernel is configured — to the `avocado-runtime` meta-package's legacy bootfiles behavior.
+
+## Var partition configuration
+
+The runtime `var` section configures the btrfs-formatted `/var` partition: a default compression algorithm and a map of subvolumes keyed by path (relative to the var root). Subvolumes can also be declared at the extension level, in which case they travel with the extension; runtime-level entries deep-merge on top and win on conflict.
+
+```yaml
+extensions:
+  my-ext:
+    subvolumes:
+      lib/docker:
+        nodatacow: true
+        quota: '10G'
+      lib/myapp/cache: true # shorthand: writable with defaults
+
+runtimes:
+  dev:
+    extensions: [my-ext]
+    var:
+      compression: 'zstd:3'
+      subvolumes:
+        lib/logs:
+          writable: true
+          compression: 'zstd:9' # per-subvolume override
+        lib/docker:
+          writable: false # override extension: make read-only
+```
+
+A built-in `lib/avocado` subvolume is always present (writable). Declaring it explicitly in runtime `var.subvolumes` suppresses the nested-path warning for extensions that live under it.
+
+### `var` fields
+
+| Field         | Default | Description                                                                                                        |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `compression` | none    | Partition-wide default compression (e.g. `zstd`, `zstd:3`, `lzo`, `zlib:6`, `no`). Overridden by per-subvolume set |
+| `subvolumes`  |         | Map of path → subvolume entry. Paths are relative to the var root                                                  |
+
+### Subvolume entry forms
+
+Each map value can be a shorthand or a full object:
+
+| Form               | Meaning                                                              |
+| ------------------ | -------------------------------------------------------------------- |
+| `true`             | Enabled, writable, inherits partition defaults                       |
+| `false`            | Disabled — suppresses an extension-declared subvolume from a runtime |
+| `"ro"`             | Enabled, read-only, inherits partition defaults                      |
+| object (see below) | Full configuration                                                   |
+
+### Subvolume object fields
+
+| Field         | Default   | Description                                                                                                      |
+| ------------- | --------- | ---------------------------------------------------------------------------------------------------------------- |
+| `writable`    | `true`    | `false` makes the subvolume read-only (applied post-mkfs via `btrfs property set ro true`)                       |
+| `compression` | inherited | Per-subvolume compression. Ignored (and skipped) when `nodatacow: true` — NOCOW disables COW                     |
+| `nodatacow`   | `false`   | Set the NOCOW inode flag via `chattr +C`. Useful for databases, VM images, and other random-write workloads      |
+| `quota`       | none      | Qgroup size limit (e.g. `500M`, `5G`, `none`). Enables btrfs quotas on the partition when any subvolume sets one |
+| `enabled`     | `true`    | Set to `false` to suppress an extension-declared subvolume from a runtime                                        |
+
+### Resolution order
+
+1. Built-in `lib/avocado` (writable).
+2. Extensions from the runtime's extension list, in order — first-listed wins on path conflicts (a warning is emitted for collisions).
+3. Runtime `var.subvolumes` deep-merges on top, always winning.
+4. Partition-level `var.compression` applied as the default for subvolumes that don't set their own.
+5. Entries with `enabled: false` are filtered out.
+
+Subvolume config is included in the runtime input hash, so changes trigger a proper var-image rebuild.
 
 ## Examples
 

--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -130,7 +130,7 @@ const config = {
             activeBasePath: 'developer-reference',
           },
           {
-            to: '/changelog/april-2026/0.34.0',
+            to: '/changelog/april-2026/0.36.0',
             label: 'Changelog',
             position: 'left',
             activeBasePath: 'changelog',

--- a/src/sidebars-changelog.js
+++ b/src/sidebars-changelog.js
@@ -8,7 +8,7 @@ const sidebars = {
       label: 'April 2026',
       collapsible: false,
       collapsed: false,
-      items: ['april-2026/0.34.0'],
+      items: ['april-2026/0.36.0', 'april-2026/0.35.0', 'april-2026/0.34.0'],
     },
     {
       type: 'category',

--- a/src/src/components/ChangelogInfiniteScroll/changelogEntries.js
+++ b/src/src/components/ChangelogInfiniteScroll/changelogEntries.js
@@ -1,6 +1,8 @@
 // Static imports of all changelog entries, ordered newest-first to match sidebars-changelog.js
 
 // -- April 2026 --
+import V0_36_0 from '../../../docs-changelog/april-2026/0.36.0.md'
+import V0_35_0 from '../../../docs-changelog/april-2026/0.35.0.md'
 import V0_34_0 from '../../../docs-changelog/april-2026/0.34.0.md'
 // -- March 2026 --
 import V0_33_0 from '../../../docs-changelog/march-2026/0.33.0.md'
@@ -41,6 +43,22 @@ import V0_8_0 from '../../../docs-changelog/september-2025/0.8.0.md'
  * Order matches sidebars-changelog.js exactly.
  */
 export const entries = [
+  {
+    version: '0.36.0',
+    monthSlug: 'april-2026',
+    monthLabel: 'April 2026',
+    permalink: '/changelog/april-2026/0.36.0',
+    Component: V0_36_0,
+  },
+
+  {
+    version: '0.35.0',
+    monthSlug: 'april-2026',
+    monthLabel: 'April 2026',
+    permalink: '/changelog/april-2026/0.35.0',
+    Component: V0_35_0,
+  },
+
   {
     version: '0.34.0',
     monthSlug: 'april-2026',


### PR DESCRIPTION
- Add 0.35.0 changelog: btrfs subvolumes, avocado connect clean, SDK arch pinning
- Add 0.36.0 changelog: kernel version pinning, runtime-scoped extensions, default_runtime config, overlay for rootfs/initramfs, lockfile v6, bug fixes
- Update commands.md: add -r/--runtime flag to ext build, clean, checkout, dnf, image, and package subcommands
- Update configuration.md: add AVOCADO_RUNTIME env var, default_runtime section, kernel configuration section, overlay section, overlay field on rootfs and initramfs
- Update sidebar and changelog redirect to point to 0.36.0 as latest