### PR TITLE
docs(cli): add supported platforms section to installation page

### DIFF
--- a/src/docs-guides/avocado-cli/installation.md
+++ b/src/docs-guides/avocado-cli/installation.md
@@ -17,7 +17,7 @@ Avocado CLI ships prebuilt binaries for the following OS / architecture combinat
 | Linux            | x86_64 (static)  | `x86_64-unknown-linux-musl`    |
 | Windows          | x86_64           | `x86_64-pc-windows-msvc`       |
 
-The Linux `*-musl` builds are statically linked and run on any Linux distribution regardless of glibc version. The `*-gnu` build is dynamically linked against glibc and is suitable for mainstream Linux distributions with glibc 2.31 or newer (Debian 11+, Ubuntu 20.04+, Fedora 33+, RHEL 9+).
+The Linux `*-musl` builds are statically linked, so they do not depend on the host glibc version, but they still require a compatible Linux kernel and matching architecture. The `*-gnu` build is dynamically linked against glibc and is suitable for mainstream Linux distributions with glibc 2.31 or newer (Debian 11+, Ubuntu 20.04+, Fedora 33+, RHEL 9+).
 
 The install script picks the appropriate binary automatically. For manual installs, download the matching artifact from the [releases page](https://github.com/avocado-linux/avocado-cli/releases).
 

--- a/src/docs-guides/avocado-cli/installation.md
+++ b/src/docs-guides/avocado-cli/installation.md
@@ -4,6 +4,25 @@ sidebar_position: 2
 description: 'Install Avocado CLI for Avocado Linux development - download, extract, and verify installation with upgrade instructions.'
 ---
 
+## Supported platforms
+
+Avocado CLI ships prebuilt binaries for the following OS / architecture combinations on every release:
+
+| Operating system | Architecture     | Target triple                  |
+| ---------------- | ---------------- | ------------------------------ |
+| macOS            | Apple Silicon    | `aarch64-apple-darwin`         |
+| macOS            | Intel            | `x86_64-apple-darwin`          |
+| Linux            | aarch64 (static) | `aarch64-unknown-linux-musl`   |
+| Linux            | x86_64 (glibc)   | `x86_64-unknown-linux-gnu`     |
+| Linux            | x86_64 (static)  | `x86_64-unknown-linux-musl`    |
+| Windows          | x86_64           | `x86_64-pc-windows-msvc`       |
+
+The Linux `*-musl` builds are statically linked and run on any Linux distribution regardless of glibc version. The `*-gnu` build is dynamically linked against glibc and is suitable for mainstream Linux distributions with glibc 2.31 or newer (Debian 11+, Ubuntu 20.04+, Fedora 33+, RHEL 9+).
+
+The install script picks the appropriate binary automatically. For manual installs, download the matching artifact from the [releases page](https://github.com/avocado-linux/avocado-cli/releases).
+
+## Install
+
 On macOS or Linux:
 
 ```bash

--- a/src/docs-guides/avocado-cli/installation.md
+++ b/src/docs-guides/avocado-cli/installation.md
@@ -8,14 +8,14 @@ description: 'Install Avocado CLI for Avocado Linux development - download, extr
 
 Avocado CLI ships prebuilt binaries for the following OS / architecture combinations on every release:
 
-| Operating system | Architecture     | Target triple                  |
-| ---------------- | ---------------- | ------------------------------ |
-| macOS            | Apple Silicon    | `aarch64-apple-darwin`         |
-| macOS            | Intel            | `x86_64-apple-darwin`          |
-| Linux            | aarch64 (static) | `aarch64-unknown-linux-musl`   |
-| Linux            | x86_64 (glibc)   | `x86_64-unknown-linux-gnu`     |
-| Linux            | x86_64 (static)  | `x86_64-unknown-linux-musl`    |
-| Windows          | x86_64           | `x86_64-pc-windows-msvc`       |
+| Operating system | Architecture     | Target triple                |
+| ---------------- | ---------------- | ---------------------------- |
+| macOS            | Apple Silicon    | `aarch64-apple-darwin`       |
+| macOS            | Intel            | `x86_64-apple-darwin`        |
+| Linux            | aarch64 (static) | `aarch64-unknown-linux-musl` |
+| Linux            | x86_64 (glibc)   | `x86_64-unknown-linux-gnu`   |
+| Linux            | x86_64 (static)  | `x86_64-unknown-linux-musl`  |
+| Windows          | x86_64           | `x86_64-pc-windows-msvc`     |
 
 The Linux `*-musl` builds are statically linked, so they do not depend on the host glibc version, but they still require a compatible Linux kernel and matching architecture. The `*-gnu` build is dynamically linked against glibc and is suitable for mainstream Linux distributions with glibc 2.31 or newer (Debian 11+, Ubuntu 20.04+, Fedora 33+, RHEL 9+).
 


### PR DESCRIPTION
## Summary

- Adds a Supported Platforms section to the CLI Installation page listing every OS/arch combination that has a release binary on the [avocado-cli releases page](https://github.com/avocado-linux/avocado-cli/releases).
- Pulled directly from the latest release (0.38.0) asset list: macOS arm64/x86_64, Linux aarch64-musl, Linux x86_64-gnu and -musl, Windows x86_64.
- Brief note on Linux build choice (musl is statically linked; gnu needs glibc 2.31+ — Debian 11+, Ubuntu 20.04+, Fedora 33+, RHEL 9+).
- Mentions that the install script picks the right binary automatically and links to the releases page for manual downloads.

## Test plan

- [ ] Visit `/developer-reference/avocado-cli/installation` locally and confirm the new section renders above the install commands.
- [ ] Check table readability in light and dark modes.
- [ ] Verify the linked releases URL works.