### PR TITLE
update hardware page links

### DIFF
--- a/src/docs-hardware/grinn/astrasom-1680/index.mdx
+++ b/src/docs-hardware/grinn/astrasom-1680/index.mdx
@@ -25,7 +25,7 @@ import HardwareHero from '@site/src/components/HardwareHero'
   ctas={{
     primary: {
       label: 'Get Started',
-      to: '/developer-reference/getting-started/any-target',
+      to: '/developer-reference/getting-started/any-target#grinn-astra-1680-sbc',
     },
     secondary: {
       label: 'Download Product Brief',

--- a/src/docs-hardware/solidrun/hummingboard-rz-v2n-aiot/index.mdx
+++ b/src/docs-hardware/solidrun/hummingboard-rz-v2n-aiot/index.mdx
@@ -10,7 +10,7 @@ import HardwareHero from '@site/src/components/HardwareHero'
 
 <HardwareHero
   vendor="SolidRun"
-  vendorUrl="https://dev.solid-run.com/renesas/rz-v2n/sbc-platform/hummingboard-iiot-rz-v2n-som-quick-start-guide"
+  vendorUrl="https://www.solid-run.com/embedded-industrial-iot/renesas-rz-family/hummingboard-rz-series-sbcs/hummingboard-rz-v2n-iiot-sbc/"
   model="HummingBoard RZ/V2N AIOT"
   tagline="Industrial-grade Physical AI platform with 15 Sparse / 4 Dense TOPS DRP-AI3, real-time Cortex-M33, and ruggedized industrial connectivity."
   image="/img/hardware/solidrun/HummingBoard-RZ_V2N-IIOT-SBC.png"
@@ -27,7 +27,7 @@ import HardwareHero from '@site/src/components/HardwareHero'
   ctas={{
     primary: {
       label: 'Get Started',
-      to: '/developer-reference/getting-started/any-target',
+      to: '/developer-reference/getting-started/any-target#rzv2n-sr-som',
     },
     secondary: {
       label: 'Download Product Brief',

--- a/src/src/components/TargetSelector/index.js
+++ b/src/src/components/TargetSelector/index.js
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react'
 import Link from '@docusaurus/Link'
+import useBrokenLinks from '@docusaurus/useBrokenLinks'
 import Heading from '@theme/Heading'
 import LinuxAutoMountWarning from '@site/src/components/shared/LinuxAutoMountWarning'
 import styles from './styles.module.css'
@@ -16,6 +17,13 @@ export default function TargetSelector() {
   const [query, setQuery] = useState('')
   const [selected, setSelected] = useState(null)
   const [isOpen, setIsOpen] = useState(false)
+
+  // Register one anchor per target with Docusaurus's broken-link checker so
+  // deep links like /any-target#rzv2n-sr-som validate at build time. The
+  // hash-driven runtime behaviour lives in the useEffect below; collectAnchor
+  // is just bookkeeping for the SSR pass.
+  const brokenLinks = useBrokenLinks()
+  targetList.forEach((target) => brokenLinks.collectAnchor(target.target))
 
   useEffect(() => {
     const hash = window.location.hash.slice(1)


### PR DESCRIPTION
Update SolidRun and Grinn AstraSOM hardware pages:

- SolidRun `vendorUrl` → product page on solid-run.com
- SolidRun Get Started CTA → `/any-target#rzv2n-sr-som` (preselects the target)
- Grinn AstraSOM Get Started CTA → `/any-target#grinn-astra-1680-sbc` (preselects the target)