### PR TITLE
docs(cli): document Homebrew install path on macOS

### DIFF
--- a/src/docs-guides/avocado-cli/installation.md
+++ b/src/docs-guides/avocado-cli/installation.md
@@ -23,13 +23,23 @@ The install script picks the appropriate binary automatically. For manual instal
 
 ## Install
 
-On macOS or Linux:
+### Homebrew (macOS)
+
+Avocado CLI is published to the [`avocado-linux/homebrew-tap`](https://github.com/avocado-linux/homebrew-tap) tap. Recommended for macOS users — Homebrew handles updates, PATH, and the Apple Silicon vs. Intel binary choice for you.
+
+```bash
+brew install avocado-linux/tap/avocado-cli
+```
+
+### Install script (macOS or Linux)
+
+A one-liner that downloads the right binary for your platform from the [releases page](https://github.com/avocado-linux/avocado-cli/releases) and installs it to `~/.local/bin`:
 
 ```bash
 curl -fsSL https://connect.peridio.com/install.sh | sh
 ```
 
-On Windows, or to install manually, use the GitHub releases:
+### Manual install (Windows, or any platform)
 
 1. Download an Avocado CLI tarball from the [releases page](https://github.com/avocado-linux/avocado-cli/releases).
 2. Extract the tarball using the following command:
@@ -47,6 +57,16 @@ On Windows, or to install manually, use the GitHub releases:
    If successful, you should see the version number displayed.
 
 ## Upgrade
+
+### Homebrew
+
+```bash
+brew upgrade avocado-cli
+```
+
+Do **not** run `avocado upgrade` on a Homebrew-installed binary — `avocado upgrade` will detect the install method and steer you back to `brew upgrade`, but the next `brew upgrade` would otherwise overwrite a self-updated binary with the formula version.
+
+### Install script or manual
 
 To upgrade to the latest version:
 


### PR DESCRIPTION
Avocado CLI now ships through the [`avocado-linux/homebrew-tap`](https://github.com/avocado-linux/homebrew-tap) tap (added in 0.39.0). Adding it as the recommended macOS install path on the Installation page:

- New **Homebrew (macOS)** section above the existing install-script section: `brew install avocado-linux/tap/avocado-cli`.
- Restructured the existing curl one-liner and manual instructions into their own subsections so the three install paths sit at the same level.
- New **Upgrade → Homebrew** subsection with `brew upgrade avocado-cli` and a note explaining why Homebrew users should not run `avocado upgrade` (the next `brew upgrade` would otherwise overwrite a self-updated binary).

## Test plan

- [x] `prettier --check` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [ ] Visit `/developer-reference/avocado-cli/installation` locally and confirm the three install subsections render in order: Homebrew, Install script, Manual.