### PR TITLE
Incorrect NVIDIA Orin AGX DevKit claims.

### DIFF
--- a/src/docs-hardware/nvidia/jetson-agx-orin/index.mdx
+++ b/src/docs-hardware/nvidia/jetson-agx-orin/index.mdx
@@ -43,7 +43,7 @@ The NVIDIA Jetson AGX Orin represents the pinnacle of edge AI computing, deliver
 | GPU            | 2048-core NVIDIA Ampere GPU        | 64 Tensor Cores for maximum inference throughput     |
 | CPU            | 12-core Arm Cortex-A78AE @ 2.2 GHz | Armv8.2 64-bit with advanced safety features         |
 | Memory         | 32GB/64GB LPDDR5                   | 204 GB/s bandwidth for complex multi-modal AI        |
-| Power          | 15-60W (75W Super)                 | Configurable power modes for any deployment scenario |
+| Power          | 15-60W                             | Configurable power modes for any deployment scenario |
 | Storage        | 64GB eUFS + NVMe                   | High-speed storage for large AI models and datasets  |
 
 ## Use Cases

--- a/src/docs-hardware/nvidia/jetson-agx-orin/index.mdx
+++ b/src/docs-hardware/nvidia/jetson-agx-orin/index.mdx
@@ -39,7 +39,7 @@ The NVIDIA Jetson AGX Orin represents the pinnacle of edge AI computing, deliver
 
 | Specification  | Value                              | Notes                                                |
 | -------------- | ---------------------------------- | ---------------------------------------------------- |
-| AI Performance | 275 TOPS                           |                                                      |
+| AI Performance | 275 TOPS                           | 275 Sparse TOPS, 138 Dense TOPS                      |
 | GPU            | 2048-core NVIDIA Ampere GPU        | 64 Tensor Cores for maximum inference throughput     |
 | CPU            | 12-core Arm Cortex-A78AE @ 2.2 GHz | Armv8.2 64-bit with advanced safety features         |
 | Memory         | 32GB/64GB LPDDR5                   | 204 GB/s bandwidth for complex multi-modal AI        |

--- a/src/docs-hardware/nvidia/jetson-agx-orin/index.mdx
+++ b/src/docs-hardware/nvidia/jetson-agx-orin/index.mdx
@@ -39,7 +39,7 @@ The NVIDIA Jetson AGX Orin represents the pinnacle of edge AI computing, deliver
 
 | Specification  | Value                              | Notes                                                |
 | -------------- | ---------------------------------- | ---------------------------------------------------- |
-| AI Performance | 275 TOPS                           | Up to 408 TOPS in JetPack 6.2 Super Mode             |
+| AI Performance | 275 TOPS                           |                                                      |
 | GPU            | 2048-core NVIDIA Ampere GPU        | 64 Tensor Cores for maximum inference throughput     |
 | CPU            | 12-core Arm Cortex-A78AE @ 2.2 GHz | Armv8.2 64-bit with advanced safety features         |
 | Memory         | 32GB/64GB LPDDR5                   | 204 GB/s bandwidth for complex multi-modal AI        |


### PR DESCRIPTION
Hi,

Your **NVIDIA Orin AGX DevKit** docs (https://docs.peridio.com/hardware/nvidia/jetson-agx-orin) claim that it has a Super Mode allowing **up to 408 TOPS** and that it can set power to **75W Super**.

I believe this is conflating the Orin Nano dev kit functionality for the TOPS claim and the Industrial Kit for the 75W Super claim.

I would be very interested if i've got this wrong, but I couldn't find any information to back up the claims.

Apologies if this isn't the correct place to raise this issue.

Thanks.