### PR TITLE
fix(hardware): correct jetson agx orin TOPS and power

### DIFF
--- a/src/docs-hardware/nvidia/jetson-agx-orin/index.mdx
+++ b/src/docs-hardware/nvidia/jetson-agx-orin/index.mdx
@@ -39,11 +39,11 @@ The NVIDIA Jetson AGX Orin represents the pinnacle of edge AI computing, deliver
 
 | Specification  | Value                              | Notes                                                |
 | -------------- | ---------------------------------- | ---------------------------------------------------- |
-| AI Performance | 275 TOPS                           | Up to 408 TOPS in JetPack 6.2 Super Mode             |
+| AI Performance | 275 TOPS                           | 275 Sparse TOPS, 138 Dense TOPS                      |
 | GPU            | 2048-core NVIDIA Ampere GPU        | 64 Tensor Cores for maximum inference throughput     |
 | CPU            | 12-core Arm Cortex-A78AE @ 2.2 GHz | Armv8.2 64-bit with advanced safety features         |
 | Memory         | 32GB/64GB LPDDR5                   | 204 GB/s bandwidth for complex multi-modal AI        |
-| Power          | 15-60W (75W Super)                 | Configurable power modes for any deployment scenario |
+| Power          | 15-60W                             | Configurable power modes for any deployment scenario |
 | Storage        | 64GB eUFS + NVMe                   | High-speed storage for large AI models and datasets  |
 
 ## Use Cases


### PR DESCRIPTION
Two corrections to `src/docs-hardware/nvidia/jetson-agx-orin/index.mdx`:

- **AI Performance** note: `Up to 408 TOPS in JetPack 6.2 Super Mode` → `275 Sparse TOPS, 138 Dense TOPS`
- **Power** value: `15-60W (75W Super)` → `15-60W`

## Test plan

- [x] `scripts/checks.sh` clean locally
- [x] Confirm the spec table renders correctly at `/hardware/nvidia/jetson-agx-orin`