### PR TITLE
Field Notes: content and UX refinements

### DIFF
--- a/.claude/skills/field-notes/SKILL.md
+++ b/.claude/skills/field-notes/SKILL.md
@@ -60,7 +60,9 @@ fabricate a number, version, or command output to fill a gap.
 ## Step 5: Produce the note
 
 Write `src/field-notes/YYYY-MM-DD-<slug>.mdx`. The filename date prefix must
-match the frontmatter `date`. Follow the template exactly: frontmatter, the
+match the frontmatter `date`. Always set `draft: true` in the frontmatter — new
+notes default to draft and stay out of the production build until verified and
+ready to ship. Follow the template exactly: frontmatter, the
 `<TestStatus>` card, a two-sentence `**TL;DR**`, the `{/* truncate */}` marker,
 the cold-reader intro, the dense body with language-tagged code blocks, a
 `<PullQuote>` for a standout number, an honest "what broke" section, and a
@@ -80,8 +82,9 @@ index, and feeds the moment it hits `main`. So:
 
 - A note with `[ENGINEER: ...]` placeholders is a reviewed-on-PR draft, not a
   merge. Keep it on the branch until the engineer who ran the demo fills them in.
-- To keep a half-finished note out of the production build while it lives on a
-  branch, set `draft: true` in the frontmatter.
+- New notes carry `draft: true` by default, which keeps them out of the
+  production build. Only flip it to `draft: false` once the note is verified,
+  has no `[ENGINEER: ...]` placeholders left, and has passed the review gate.
 - The light review gate: one engineer confirms the reproducible core actually
   reproduces on a fresh setup and the `tested_against` versions are accurate.
 

--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -19,13 +19,15 @@ const config = {
   organizationName: 'peridio',
   projectName: 'peridio-docs',
   trailingSlash: false,
-  clientModules: ['./src/clientModules/copyInlineCode.js'],
+  clientModules: [
+    './src/clientModules/copyInlineCode.js',
+    './src/clientModules/imageLightbox.js',
+  ],
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],
   },
   plugins: [
-    'docusaurus-plugin-image-zoom',
     './plugins/yaml-loader-plugin',
     [
       '@docusaurus/plugin-client-redirects',
@@ -241,14 +243,6 @@ const config = {
             block: { start: 'highlight-orange-start', end: 'highlight-orange-end' },
           },
         ],
-      },
-      zoom: {
-        selector: '.markdown img',
-        background: {
-          light: 'rgb(255, 255, 255)',
-          dark: 'rgb(50, 50, 50)',
-        },
-        config: {},
       },
     }),
   headTags: [

--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -19,10 +19,7 @@ const config = {
   organizationName: 'peridio',
   projectName: 'peridio-docs',
   trailingSlash: false,
-  clientModules: [
-    './src/clientModules/copyInlineCode.js',
-    './src/clientModules/imageLightbox.js',
-  ],
+  clientModules: ['./src/clientModules/copyInlineCode.js', './src/clientModules/imageLightbox.js'],
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],

--- a/src/field-notes/2026-06-15-power-pull-orin-nx.mdx
+++ b/src/field-notes/2026-06-15-power-pull-orin-nx.mdx
@@ -2,6 +2,7 @@
 title: 'Pulling the power 200 times mid-OTA on an Orin NX'
 description: "200 scripted power cuts at random points during an A/B OTA update. Zero bricks at steady state — and the two early failures weren't where we expected."
 date: 2026-06-15
+draft: true
 authors: [jschneck]
 tags: [ota, rollback, jetson, orin-nx]
 category: 'Reliability'

--- a/src/field-notes/CONTRIBUTING.md
+++ b/src/field-notes/CONTRIBUTING.md
@@ -127,4 +127,4 @@ A note checked in with `[ENGINEER: paste the boot log here]` placeholders is a s
   grep -l "\[ENGINEER:" *.mdx
   ```
 
-Every new note starts with `draft: true` in its front matter — the template ships it that way. Docusaurus' `draft: true` excludes the post from production builds entirely, so a note stays out of the public build until it's true, complete, and reviewed. Flip it to `draft: false` (or remove it) only once no `[ENGINEER: ...]` placeholders remain and the note has passed the review gate.
+Every new note starts with `draft: true` in its front matter — the template ships it that way. Docusaurus' `draft: true` excludes the post from production builds entirely, so a note stays out of the public build until it's accurate, complete, and reviewed. Flip it to `draft: false` (or remove it) only once no `[ENGINEER: ...]` placeholders remain and the note has passed the review gate.

--- a/src/field-notes/CONTRIBUTING.md
+++ b/src/field-notes/CONTRIBUTING.md
@@ -127,4 +127,4 @@ A note checked in with `[ENGINEER: paste the boot log here]` placeholders is a s
   grep -l "\[ENGINEER:" *.mdx
   ```
 
-If you need to keep a half-finished note out of the public build while it lives on a longer-running branch, use Docusaurus' `draft: true` front matter — it excludes the post from production builds entirely.
+Every new note starts with `draft: true` in its front matter — the template ships it that way. Docusaurus' `draft: true` excludes the post from production builds entirely, so a note stays out of the public build until it's true, complete, and reviewed. Flip it to `draft: false` (or remove it) only once no `[ENGINEER: ...]` placeholders remain and the note has passed the review gate.

--- a/src/field-notes/_template.mdx
+++ b/src/field-notes/_template.mdx
@@ -21,7 +21,7 @@ promote_to_track: '' # on-ramp candidate? note the target tutorial
       name: Jane Doe
       title: Avocado OS, Peridio
       image_url: /img/field-notes/authors/jdoe.svg   (a small monogram/photo; optional)
-  Then set authors: [jdoe] above. The byline renders name + title + avatar
+  Then set authors: [jdoe] above. The byline renders name + title
   automatically (link-free — a browser-extension overlay quirk we sidestep).
 
   Images: put them in static/img/field-notes/ and reference as /img/field-notes/<name>.

--- a/src/field-notes/_template.mdx
+++ b/src/field-notes/_template.mdx
@@ -2,6 +2,7 @@
 title: ''
 description: '' # one-line dek — used as the index summary and the page meta description
 date: YYYY-MM-DD
+draft: true # new notes start as drafts (kept out of the production build); flip to false only once verified and ready to ship
 authors: [] # keys from authors.yml — add yourself there first (see note below)
 tags: [] # target + topic; rendered as pills in the masthead
 category: '' # short label shown above the title on the index; falls back to the first tag

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -18,7 +18,6 @@
         "@svgr/webpack": "^8.1.0",
         "@types/react": "^19.1.10",
         "clsx": "^2.1.1",
-        "docusaurus-plugin-image-zoom": "^3.0.1",
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -9479,19 +9478,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/docusaurus-plugin-image-zoom": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-3.0.1.tgz",
-      "integrity": "sha512-mQrqA99VpoMQJNbi02qkWAMVNC4+kwc6zLLMNzraHAJlwn+HrlUmZSEDcTwgn+H4herYNxHKxveE2WsYy73eGw==",
-      "license": "MIT",
-      "dependencies": {
-        "medium-zoom": "^1.1.0",
-        "validate-peer-dependencies": "^2.2.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/theme-classic": ">=3.0.0"
-      }
-    },
     "node_modules/docusaurus-plugin-redoc": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-2.5.0.tgz",
@@ -14499,12 +14485,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/medium-zoom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.1.0.tgz",
-      "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==",
-      "license": "MIT"
-    },
     "node_modules/memfs": {
       "version": "4.48.1",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.48.1.tgz",
@@ -17439,27 +17419,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
-    },
-    "node_modules/path-root": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
-      "license": "MIT",
-      "dependencies": {
-        "path-root-regex": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-root-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
@@ -20411,18 +20370,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-package-path": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
-      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-root": "^0.1.1"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/resolve-pathname": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
@@ -22907,31 +22854,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/validate-peer-dependencies": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/validate-peer-dependencies/-/validate-peer-dependencies-2.2.0.tgz",
-      "integrity": "sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==",
-      "license": "MIT",
-      "dependencies": {
-        "resolve-package-path": "^4.0.3",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/validate-peer-dependencies/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/value-equal": {

--- a/src/package.json
+++ b/src/package.json
@@ -29,7 +29,6 @@
     "@svgr/webpack": "^8.1.0",
     "@types/react": "^19.1.10",
     "clsx": "^2.1.1",
-    "docusaurus-plugin-image-zoom": "^3.0.1",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/src/src/clientModules/imageLightbox.js
+++ b/src/src/clientModules/imageLightbox.js
@@ -1,0 +1,209 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment'
+
+// Selector for images that should open in the zoomable lightbox.
+const SELECTOR = '.markdown img'
+const MIN_SCALE = 1
+const MAX_SCALE = 8
+const WHEEL_STEP = 0.0015
+const BUTTON_STEP = 1.4
+
+if (ExecutionEnvironment.canUseDOM) {
+  let overlay
+  let imgEl
+  let scale = 1
+  let tx = 0
+  let ty = 0
+
+  // Pointer / drag state.
+  let dragging = false
+  let lastX = 0
+  let lastY = 0
+  // Active pointers for pinch handling (pointerId -> {x, y}).
+  const pointers = new Map()
+  let pinchStartDist = 0
+  let pinchStartScale = 1
+
+  const clamp = (v, min, max) => Math.min(Math.max(v, min), max)
+
+  function apply() {
+    imgEl.style.transform = `translate(${tx}px, ${ty}px) scale(${scale})`
+    imgEl.style.cursor = scale > 1 ? (dragging ? 'grabbing' : 'grab') : 'zoom-out'
+  }
+
+  // Zoom toward a screen point (sx, sy measured from viewport center).
+  function zoomTo(nextScale, sx, sy) {
+    const s = clamp(nextScale, MIN_SCALE, MAX_SCALE)
+    const cx = (sx - tx) / scale
+    const cy = (sy - ty) / scale
+    tx = sx - s * cx
+    ty = sy - s * cy
+    scale = s
+    if (scale === 1) {
+      tx = 0
+      ty = 0
+    }
+    apply()
+  }
+
+  function reset() {
+    scale = 1
+    tx = 0
+    ty = 0
+    apply()
+  }
+
+  function build() {
+    overlay = document.createElement('div')
+    overlay.className = 'img-lightbox'
+    overlay.setAttribute('role', 'dialog')
+    overlay.setAttribute('aria-modal', 'true')
+    overlay.setAttribute('aria-label', 'Image viewer')
+
+    imgEl = document.createElement('img')
+    imgEl.className = 'img-lightbox__img'
+    imgEl.draggable = false
+
+    const controls = document.createElement('div')
+    controls.className = 'img-lightbox__controls'
+    controls.innerHTML = `
+      <button type="button" class="img-lightbox__btn" data-action="zoom-out" aria-label="Zoom out">&minus;</button>
+      <button type="button" class="img-lightbox__btn" data-action="reset" aria-label="Reset zoom">Reset</button>
+      <button type="button" class="img-lightbox__btn" data-action="zoom-in" aria-label="Zoom in">+</button>
+      <button type="button" class="img-lightbox__btn img-lightbox__btn--close" data-action="close" aria-label="Close">&times;</button>
+    `
+
+    overlay.appendChild(imgEl)
+    overlay.appendChild(controls)
+    document.body.appendChild(overlay)
+
+    wireEvents()
+  }
+
+  function open(src, alt) {
+    if (!overlay) build()
+    imgEl.src = src
+    imgEl.alt = alt || ''
+    reset()
+    // Force reflow so the opening transition runs.
+    void overlay.offsetWidth
+    overlay.classList.add('img-lightbox--open')
+    document.body.classList.add('img-lightbox-lock')
+  }
+
+  function close() {
+    if (!overlay) return
+    overlay.classList.remove('img-lightbox--open')
+    document.body.classList.remove('img-lightbox-lock')
+    pointers.clear()
+    dragging = false
+  }
+
+  function isOpen() {
+    return overlay && overlay.classList.contains('img-lightbox--open')
+  }
+
+  function wireEvents() {
+    // Control buttons.
+    overlay.querySelector('.img-lightbox__controls').addEventListener('click', (e) => {
+      const btn = e.target.closest('[data-action]')
+      if (!btn) return
+      const action = btn.dataset.action
+      if (action === 'zoom-in') zoomTo(scale * BUTTON_STEP, 0, 0)
+      else if (action === 'zoom-out') zoomTo(scale / BUTTON_STEP, 0, 0)
+      else if (action === 'reset') reset()
+      else if (action === 'close') close()
+    })
+
+    // Click backdrop (not the image) to close.
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) close()
+    })
+
+    // Double-click the image to toggle zoom.
+    imgEl.addEventListener('dblclick', (e) => {
+      const sx = e.clientX - window.innerWidth / 2
+      const sy = e.clientY - window.innerHeight / 2
+      zoomTo(scale > 1 ? 1 : 2.5, sx, sy)
+    })
+
+    // Wheel zoom centered on the cursor.
+    overlay.addEventListener(
+      'wheel',
+      (e) => {
+        e.preventDefault()
+        const sx = e.clientX - window.innerWidth / 2
+        const sy = e.clientY - window.innerHeight / 2
+        zoomTo(scale * (1 - e.deltaY * WHEEL_STEP), sx, sy)
+      },
+      { passive: false }
+    )
+
+    // Pointer-based drag pan + pinch zoom.
+    imgEl.addEventListener('pointerdown', (e) => {
+      pointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
+      imgEl.setPointerCapture(e.pointerId)
+      if (pointers.size === 2) {
+        const [a, b] = [...pointers.values()]
+        pinchStartDist = Math.hypot(a.x - b.x, a.y - b.y)
+        pinchStartScale = scale
+      } else if (scale > 1) {
+        dragging = true
+        lastX = e.clientX
+        lastY = e.clientY
+        apply()
+      }
+    })
+
+    imgEl.addEventListener('pointermove', (e) => {
+      if (!pointers.has(e.pointerId)) return
+      pointers.set(e.pointerId, { x: e.clientX, y: e.clientY })
+
+      if (pointers.size === 2) {
+        const [a, b] = [...pointers.values()]
+        const dist = Math.hypot(a.x - b.x, a.y - b.y)
+        const midX = (a.x + b.x) / 2 - window.innerWidth / 2
+        const midY = (a.y + b.y) / 2 - window.innerHeight / 2
+        if (pinchStartDist > 0) {
+          zoomTo(pinchStartScale * (dist / pinchStartDist), midX, midY)
+        }
+        return
+      }
+
+      if (dragging) {
+        tx += e.clientX - lastX
+        ty += e.clientY - lastY
+        lastX = e.clientX
+        lastY = e.clientY
+        apply()
+      }
+    })
+
+    const endPointer = (e) => {
+      pointers.delete(e.pointerId)
+      if (pointers.size < 2) pinchStartDist = 0
+      if (pointers.size === 0) dragging = false
+      apply()
+    }
+    imgEl.addEventListener('pointerup', endPointer)
+    imgEl.addEventListener('pointercancel', endPointer)
+
+    // Keyboard controls.
+    document.addEventListener('keydown', (e) => {
+      if (!isOpen()) return
+      if (e.key === 'Escape') close()
+      else if (e.key === '+' || e.key === '=') zoomTo(scale * BUTTON_STEP, 0, 0)
+      else if (e.key === '-' || e.key === '_') zoomTo(scale / BUTTON_STEP, 0, 0)
+      else if (e.key === '0') reset()
+    })
+  }
+
+  // Delegate clicks from doc images to open the lightbox.
+  document.addEventListener('click', (e) => {
+    const img = e.target.closest(SELECTOR)
+    if (!img) return
+    // Skip images wrapped in links — let the link do its job.
+    if (img.closest('a')) return
+    e.preventDefault()
+    open(img.currentSrc || img.src, img.alt)
+  })
+}

--- a/src/src/clientModules/imageLightbox.js
+++ b/src/src/clientModules/imageLightbox.js
@@ -13,6 +13,8 @@ if (ExecutionEnvironment.canUseDOM) {
   let scale = 1
   let tx = 0
   let ty = 0
+  // Element focused before the lightbox opened, so focus can be restored on close.
+  let lastFocused = null
 
   // Pointer / drag state.
   let dragging = false
@@ -58,6 +60,8 @@ if (ExecutionEnvironment.canUseDOM) {
     overlay.setAttribute('role', 'dialog')
     overlay.setAttribute('aria-modal', 'true')
     overlay.setAttribute('aria-label', 'Image viewer')
+    // Focusable so we can move focus into the modal on open (aria-modal semantics).
+    overlay.tabIndex = -1
 
     imgEl = document.createElement('img')
     imgEl.className = 'img-lightbox__img'
@@ -81,6 +85,7 @@ if (ExecutionEnvironment.canUseDOM) {
 
   function open(src, alt) {
     if (!overlay) build()
+    lastFocused = document.activeElement
     imgEl.src = src
     imgEl.alt = alt || ''
     reset()
@@ -88,6 +93,8 @@ if (ExecutionEnvironment.canUseDOM) {
     void overlay.offsetWidth
     overlay.classList.add('img-lightbox--open')
     document.body.classList.add('img-lightbox-lock')
+    // Move focus into the dialog for keyboard/screen-reader users.
+    overlay.focus()
   }
 
   function close() {
@@ -96,6 +103,11 @@ if (ExecutionEnvironment.canUseDOM) {
     document.body.classList.remove('img-lightbox-lock')
     pointers.clear()
     dragging = false
+    // Restore focus to the element that opened the lightbox.
+    if (lastFocused && typeof lastFocused.focus === 'function') {
+      lastFocused.focus()
+    }
+    lastFocused = null
   }
 
   function isOpen() {

--- a/src/src/css/custom.css
+++ b/src/src/css/custom.css
@@ -1320,6 +1320,12 @@ html[data-theme="dark"] .plugin-id-field-notes {
   cursor: zoom-in;
 }
 
+/* Linked images navigate (the lightbox skips them), so show the link
+   affordance instead of the misleading zoom-in cursor. */
+.markdown a img {
+  cursor: pointer;
+}
+
 .img-lightbox {
   position: fixed;
   inset: 0;

--- a/src/src/css/custom.css
+++ b/src/src/css/custom.css
@@ -1312,3 +1312,93 @@ html[data-theme="dark"] .plugin-id-field-notes {
 .plugin-id-field-notes .table-of-contents__link--active {
   color: var(--field-notes-accent);
 }
+
+/* ── Image lightbox (zoom + pan) ───────────────────────────── */
+/* Sits above the navbar (200), mega-menu (9999) and DocSearch (10000). */
+.markdown img {
+  cursor: zoom-in;
+}
+
+.img-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(12, 12, 14, 0.92);
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    opacity 0.2s ease,
+    visibility 0.2s ease;
+  overflow: hidden;
+  touch-action: none;
+}
+
+.img-lightbox--open {
+  opacity: 1;
+  visibility: visible;
+}
+
+.img-lightbox__img {
+  max-width: 92vw;
+  max-height: 92vh;
+  transform-origin: center center;
+  transition: transform 0.08s linear;
+  user-select: none;
+  -webkit-user-drag: none;
+  border-radius: 4px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+}
+
+.img-lightbox__controls {
+  position: fixed;
+  bottom: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: rgba(30, 30, 34, 0.9);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+.img-lightbox__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  height: 2.25rem;
+  padding: 0 0.75rem;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: #f2f2f4;
+  font-size: 1.1rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.img-lightbox__btn[data-action="reset"] {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.img-lightbox__btn:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.img-lightbox__btn--close {
+  margin-left: 0.15rem;
+  font-size: 1.4rem;
+}
+
+.img-lightbox-lock {
+  overflow: hidden;
+}

--- a/src/src/css/custom.css
+++ b/src/src/css/custom.css
@@ -60,6 +60,13 @@ main {
 
 html {
   font-family: "Inter", sans-serif;
+  /* Always reserve the vertical scrollbar's gutter so the viewport width never
+     changes when content grows/shrinks (e.g. Field Notes cards + images loading
+     in). Without this, the centered `.navbar__inner` shifts sideways every time
+     the scrollbar toggles — the horizontal "flicker" seen on the nav row.
+     No-op for overlay-scrollbar setups; only reserves space where scrollbars
+     are classic (macOS with a mouse, most desktop OSes). */
+  scrollbar-gutter: stable;
 }
 
 /* Dark-mode colors are owned by the token system
@@ -251,36 +258,6 @@ html[data-theme="dark"] .navbar {
   display: flex;
 }
 
-/* Nav link styles — underline active indicators */
-.navbar__items--nav > a {
-  padding: 0.35rem 0;
-  margin-right: 2rem;
-  margin-bottom: 0;
-  position: relative;
-  bottom: -1px;
-  font-size: 0.875rem;
-  font-weight: 400;
-  color: var(--ifm-color-emphasis-600);
-  border-bottom: 3px solid transparent;
-  transition:
-    color 0.15s,
-    border-color 0.15s;
-}
-
-.navbar__items--nav > a:hover {
-  background: none;
-  color: var(--ifm-color-primary);
-  border-bottom-color: transparent;
-}
-
-.navbar__items--nav > a.navbar__link--active {
-  font-weight: 500;
-  color: var(--ifm-font-color-base);
-  border-bottom: 3px solid var(--ifm-color-primary);
-}
-
-/* Duplicate icon definitions and icon-hiding rule removed — icons are defined below at lines 350+ */
-
 /* Left items container — wrap so logo is row 1, links are row 2 */
 .navbar__items:not(.navbar__items--right) {
   flex-wrap: wrap !important;
@@ -292,24 +269,36 @@ html[data-theme="dark"] .navbar {
   padding: 0.6rem 0;
 }
 
-/* Nav link items sit below logo */
+/* Nav link items sit below logo.
+   Single authoritative definition for the nav tabs — every sizing property
+   (weight, font-size, padding, margin, border-width) is identical across the
+   default, hover, and active states, so the tab's box never changes size and
+   neighboring tabs never shift. Only color and border *color* change between
+   states, and both are transitioned. Keep it this way: reintroducing a second
+   rule set that also matches these links resurrects the width-shift flicker. */
 .navbar__items:not(.navbar__items--right) > .navbar__link {
+  position: relative;
+  bottom: -1px;
   padding: 0.6rem 0;
   margin-right: 1.5rem;
   font-size: 0.95rem;
-  font-weight: 500;
+  font-weight: 700;
+  color: var(--ifm-color-emphasis-600);
   border-bottom: 2px solid transparent;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
 }
 
 .navbar__items:not(.navbar__items--right) > .navbar__link:hover {
   background: none;
+  color: var(--ifm-color-primary);
   border-bottom-color: var(--ifm-color-primary);
 }
 
 .navbar__items:not(.navbar__items--right) > .navbar__link--active {
-  font-weight: 700;
-  border-bottom: 2px solid var(--ifm-color-primary);
   color: var(--ifm-color-primary);
+  border-bottom-color: var(--ifm-color-primary);
 }
 
 /* Nav icons — using mask so color follows text color */
@@ -327,7 +316,9 @@ html[data-theme="dark"] .navbar {
   mask-repeat: no-repeat;
   -webkit-mask-position: center;
   mask-position: center;
-  opacity: 0.7;
+  /* Full opacity in every state so the icon looks identical whether the tab is
+     default, hovered, or active — no brightness shift, no perceived movement */
+  opacity: 1;
 }
 
 .navbar__items:not(.navbar__items--right) > .navbar__link:hover::before,
@@ -1193,6 +1184,16 @@ html[data-theme="dark"] .plugin-id-field-notes {
 .plugin-id-field-notes kbd,
 .plugin-id-field-notes pre {
   font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* The page-level Geist font above is set on the body (.plugin-id-field-notes),
+   so global chrome inherits it — making the navbar (and its Field Notes tab)
+   render in a different font on this page than on every other page. Keep the
+   navbar in the site's base font everywhere so the tabs look identical whether
+   or not Field Notes is the active route. */
+.plugin-id-field-notes .navbar,
+.plugin-id-field-notes .navbar__link {
+  font-family: var(--ifm-font-family-base);
 }
 
 /* Layout: drop the col--offset-1 and let the article fill the area that

--- a/src/src/theme/BlogPostItem/Header/index.js
+++ b/src/src/theme/BlogPostItem/Header/index.js
@@ -37,7 +37,7 @@ function HeaderDate() {
 
 // Custom, link-free byline. The theme default links each author to their author
 // page (<a href>), and a password-manager browser extension latched onto those
-// links to draw a stray overlay box. Rendering the author as plain text + image
+// links to draw a stray overlay box. Rendering the author as plain text
 // removes the link entirely and gives us full design control.
 function Byline() {
   const { metadata } = useBlogPost()

--- a/src/src/theme/BlogPostItem/Header/index.js
+++ b/src/src/theme/BlogPostItem/Header/index.js
@@ -47,15 +47,6 @@ function Byline() {
     <div className={styles.byline}>
       {authors.map((author, i) => (
         <div className={styles.author} key={author.key ?? author.name ?? i}>
-          {author.imageURL ? (
-            <img
-              className={styles.avatar}
-              src={author.imageURL}
-              alt={author.name || ''}
-              width={44}
-              height={44}
-            />
-          ) : null}
           <div className={styles.authorText}>
             {author.name ? <span className={styles.authorName}>{author.name}</span> : null}
             {author.title ? <span className={styles.authorTitle}>{author.title}</span> : null}

--- a/src/src/theme/BlogPostItem/Header/styles.module.css
+++ b/src/src/theme/BlogPostItem/Header/styles.module.css
@@ -103,16 +103,6 @@
   }
 }
 
-.avatar {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  flex: none;
-  display: block;
-  box-shadow: 0 0 0 2px
-    color-mix(in srgb, var(--field-notes-accent, var(--ifm-color-primary)) 35%, transparent);
-}
-
 .authorText {
   display: flex;
   flex-direction: column;

--- a/src/src/theme/BlogPostItems/index.js
+++ b/src/src/theme/BlogPostItems/index.js
@@ -44,7 +44,7 @@ function Eyebrow({ post, isFeatured }) {
       {isDraft(post) && (
         <span
           className={styles.draftBadge}
-          data-tooltip="Only visible in local dev. Remove the draft flag to publish this note to the live feed."
+          data-tooltip="Draft marker — this note carries a draft flag or tag. Clear it to publish the note to the live feed."
         >
           Draft
         </span>

--- a/src/src/theme/BlogPostItems/index.js
+++ b/src/src/theme/BlogPostItems/index.js
@@ -25,6 +25,34 @@ function categoryLabel(post, isFeatured) {
   return metadata.tags?.[0]?.label ?? 'Field Note'
 }
 
+// Internal-only marker. A note counts as a draft when its front matter carries
+// `draft: true` (hidden from the published feed, visible in local dev) or when
+// it's tagged `draft`. When either is true we surface a small badge next to the
+// eyebrow so editors can spot unfinished notes at a glance; it disappears the
+// moment the draft flag/tag is removed.
+function isDraft(post) {
+  const { frontMatter, metadata } = post
+  if (frontMatter.draft) return true
+  return (metadata.tags ?? []).some((t) => (t.label ?? '').toLowerCase() === 'draft')
+}
+
+// The eyebrow line: category label plus, for drafts, the internal Draft badge.
+function Eyebrow({ post, isFeatured }) {
+  return (
+    <p className={styles.eyebrow}>
+      {categoryLabel(post, isFeatured)}
+      {isDraft(post) && (
+        <span
+          className={styles.draftBadge}
+          data-tooltip="Only visible in local dev. Remove the draft flag to publish this note to the live feed."
+        >
+          Draft
+        </span>
+      )}
+    </p>
+  )
+}
+
 function Thumb({ post, className }) {
   const { image, image_alt: imageAlt } = post.frontMatter
   return (
@@ -65,7 +93,7 @@ function FeaturedItem({ post }) {
     <article className={styles.featured}>
       <Thumb post={post} className={styles.featuredThumb} />
       <div>
-        <p className={styles.eyebrow}>{categoryLabel(post, true)}</p>
+        <Eyebrow post={post} isFeatured />
         <Heading as="h2" className={styles.featuredTitle}>
           <Link to={metadata.permalink}>{metadata.title}</Link>
         </Heading>
@@ -83,7 +111,7 @@ function Row({ post }) {
     <article className={styles.row}>
       <Thumb post={post} className={styles.rowThumb} />
       <div>
-        <p className={styles.eyebrow}>{categoryLabel(post, false)}</p>
+        <Eyebrow post={post} isFeatured={false} />
         <Heading as="h2" className={styles.title}>
           <Link to={metadata.permalink}>{metadata.title}</Link>
         </Heading>

--- a/src/src/theme/BlogPostItems/styles.module.css
+++ b/src/src/theme/BlogPostItems/styles.module.css
@@ -44,7 +44,7 @@
 
 /* Custom hover tooltip for the Draft badge. Native `title` is unreliable inside
    the card link, so we render the reminder ourselves via a data attribute. */
-.draftBadge::after {
+.draftBadge[data-tooltip]::after {
   content: attr(data-tooltip);
   position: absolute;
   bottom: calc(100% + 8px);
@@ -72,7 +72,7 @@
 }
 
 /* Small arrow pointing down to the badge. */
-.draftBadge::before {
+.draftBadge[data-tooltip]::before {
   content: "";
   position: absolute;
   bottom: calc(100% + 3px);
@@ -88,8 +88,8 @@
     transform 0.15s ease;
 }
 
-.draftBadge:hover::after,
-.draftBadge:hover::before {
+.draftBadge[data-tooltip]:hover::after,
+.draftBadge[data-tooltip]:hover::before {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }

--- a/src/src/theme/BlogPostItems/styles.module.css
+++ b/src/src/theme/BlogPostItems/styles.module.css
@@ -22,6 +22,74 @@
   margin: 0 0 0.85rem 0;
 }
 
+/* Internal-only "Draft" badge shown beside the eyebrow for unpublished notes
+   (front matter `draft: true` or a `draft` tag). Amber so it reads as a status
+   marker distinct from the purple category accent; it vanishes when the draft
+   flag/tag is removed. */
+.draftBadge {
+  position: relative;
+  display: inline-block;
+  margin-left: 0.6em;
+  padding: 0.1em 0.5em;
+  border: 1px solid var(--ifm-color-warning-dark, #b9820c);
+  border-radius: 3px;
+  color: var(--ifm-color-warning-dark, #b9820c);
+  background: color-mix(in srgb, var(--ifm-color-warning, #f5a623) 14%, transparent);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  vertical-align: 0.08em;
+  cursor: help;
+}
+
+/* Custom hover tooltip for the Draft badge. Native `title` is unreliable inside
+   the card link, so we render the reminder ourselves via a data attribute. */
+.draftBadge::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  z-index: 10;
+  width: max-content;
+  max-width: 240px;
+  padding: 0.7em 0.9em;
+  border-radius: 6px;
+  background: var(--ifm-color-warning, #f5a623);
+  color: #1c1e21;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: normal;
+  line-height: 1.45;
+  text-align: left;
+  white-space: normal;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+/* Small arrow pointing down to the badge. */
+.draftBadge::before {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 3px);
+  left: 50%;
+  z-index: 10;
+  border: 5px solid transparent;
+  border-top-color: var(--ifm-color-warning, #f5a623);
+  transform: translateX(-50%) translateY(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.draftBadge:hover::after,
+.draftBadge:hover::before {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
 .meta {
   font-family: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.8rem;

--- a/src/src/theme/BlogPostItems/styles.module.css
+++ b/src/src/theme/BlogPostItems/styles.module.css
@@ -66,7 +66,9 @@
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
 }
 
 /* Small arrow pointing down to the badge. */
@@ -81,7 +83,9 @@
   transform: translateX(-50%) translateY(4px);
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
 }
 
 .draftBadge:hover::after,


### PR DESCRIPTION
Refinements to the Field Notes feed covering content workflow and reading experience.

## Changes

- **Draft-by-default workflow** — new notes start with `draft: true` in the template so they stay out of the production build until verified. `SKILL.md` and `CONTRIBUTING.md` document the flow and the review gate.
- **Draft badge** — an internal amber "Draft" badge on the feed eyebrow for draft notes (front-matter flag or `draft` tag), with a local-dev-only hover tooltip. The Orin NX note is marked as draft.
- **Byline** — dropped author avatars from the Field Notes byline.
- **Navbar** — stabilized navbar tabs across states and pages.
- **Lightbox** — replaced the image-zoom plugin with a custom lightbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)