### PR TITLE
Field Notes: publish the portability note and clear review nits

### DIFF
--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -99,7 +99,7 @@ const config = {
         path: 'field-notes',
         blogTitle: 'Field Notes',
         blogDescription:
-          'Technical write-ups from the Peridio team — what we are working on, decisions we made, and stories from the field.  Engineering content only.',
+          'Technical write-ups from the Peridio team — what we are working on, decisions we made, and stories from the field. Engineering content only.',
         showReadingTime: false,
         postsPerPage: 20,
         blogSidebarCount: 0,

--- a/src/field-notes/2026-06-22-fastest-path-ai-vision-nvidia.mdx
+++ b/src/field-notes/2026-06-22-fastest-path-ai-vision-nvidia.mdx
@@ -21,7 +21,7 @@ import TestStatus from '@site/src/components/TestStatus'
   }}
 />
 
-**TL;DR** — We made a demo with some fancy people tracking! It runs on NVIDIA hardware, uses the GPU, runs at 30fps, it tracks people, draws fun lines, and it takes minutes to to go from nothing to a custom, production ready OS running this demo.
+**TL;DR** — We made a demo with some fancy people tracking! It runs on NVIDIA hardware, uses the GPU, runs at 30fps, it tracks people, draws fun lines, and it takes minutes to go from nothing to a custom, production-ready OS running this demo.
 
 {/* truncate */}
 

--- a/src/field-notes/2026-07-01-nodejs-dashboard-portability.mdx
+++ b/src/field-notes/2026-07-01-nodejs-dashboard-portability.mdx
@@ -2,13 +2,12 @@
 title: 'From QEMU to Raspberry Pi to Jetson - one codebase, ultimate portability'
 description: 'Moving an app across boards usually means standing up a new build per board. On Avocado OS the same Node.js dashboard runs on a QEMU VM, a Raspberry Pi 5, and a Jetson Orin Nano by changing one line: the target.'
 date: 2026-07-01
-draft: true # excluded from the published build until the [ENGINEER:] placeholder is filled
 authors: [nsinas]
 tags: [portability, multi-target, rpi5, jetson-orin-nano, nodejs]
 category: 'Portability'
 image: /img/field-notes/nodejs-dashboard-portability.png # hero thumbnail on the index
 featured: false
-tested_against: 'Avocado CLI 0.41.1, nodejs-dashboard reference; targets qemux86-64, raspberrypi5, jetson-orin-nano-devkit [ENGINEER: board revisions + host OS/chip]'
+tested_against: 'Avocado CLI 0.41.1, nodejs-dashboard reference; targets qemux86-64, raspberrypi5, jetson-orin-nano-devkit'
 poster: nsinas
 lift_for_blog: 'The per-board rebuild that comes with moving an app across hardware, removed: one source tree ships to three targets by changing the target line.'
 promote_to_track: 'Tutorial candidate: same-app-across-targets as the portability chapter of the on-ramp.'

--- a/src/src/components/TestStatus/index.jsx
+++ b/src/src/components/TestStatus/index.jsx
@@ -42,7 +42,7 @@ export default function TestStatus({ targets = [], cli, reference }) {
         {reference && (
           <div className={styles.field}>
             <span className={styles.key}>Reference</span>
-            <Link to={reference.href} className={styles.repo}>
+            <Link href={reference.href} className={styles.repo}>
               <GitHubIcon />
               {reference.label}
             </Link>


### PR DESCRIPTION
Follow-up to #439.

## Publishes the Node.js portability note

`2026-07-01-nodejs-dashboard-portability.mdx` was held as a draft over a `tested_against` placeholder for board revisions + host chip. The author (Nick) confirmed it's a portability demonstration, not a benchmark — the point is that one target-line change carries the same source across QEMU, a Pi 5, and a Jetson, so exact hardware revisions aren't load-bearing. Dropped `draft: true` and trimmed the placeholder to the verified line (CLI 0.41.1 + the three named targets). This becomes the 5th published note.

## Clears the deferred review findings (ENG-2054)

- Two TL;DR typos in the NVIDIA note ("minutes to to" → "to", "production ready" → "production-ready")
- Double space in the blog description string
- External reference URL now passed via `href` instead of `to` in `TestStatus`
- Author avatar made decorative (`alt=""` + `aria-hidden`) so screen readers don't announce the name twice

The two latent items in ENG-2054 (multi-featured hero guard, CSS plugin-id scoping) are left as-is — neither can manifest today.

## Test

`make build` succeeds; the portability note now renders in the published feed, whole tree passes `prettier --check`.