### PR TITLE
Add a Download & Install page to Getting Started

### DIFF
--- a/src/docs-guides/getting-started/download.md
+++ b/src/docs-guides/getting-started/download.md
@@ -1,0 +1,48 @@
+---
+title: Download & Install
+sidebar_position: 1
+description: 'Download Avocado Desktop for macOS and install the Avocado CLI - the two ways to get Avocado running on your machine.'
+---
+
+Avocado ships two pieces of software you install locally:
+
+- **Avocado Desktop** - a native app that runs and manages Avocado on your own machine.
+- **Avocado CLI** - the command-line tool for builds, automation, CI, and headless Linux.
+
+Most people start with the desktop app. Reach for the CLI when you are scripting builds, running in CI, or working on a headless Linux host.
+
+## Avocado Desktop
+
+Avocado Desktop is available for macOS today. Windows and Linux are on the way.
+
+### macOS
+
+Avocado Desktop requires macOS 13.0 (Ventura) or later.
+
+Download the latest release directly:
+
+- [Download Avocado Desktop for macOS](https://repo.avocadolinux.org/releases/desktop/stable/Avocado-0.4.4.dmg)
+
+Or install it with [Homebrew](https://brew.sh):
+
+```bash
+brew install --cask avocado-desktop
+```
+
+Once installed, the app updates itself in place, so you do not need to re-download it for new releases.
+
+### Windows and Linux
+
+Desktop builds for Windows and Linux are coming soon. Until then, use the Avocado CLI below - it already runs on both.
+
+## Avocado CLI
+
+On macOS or Linux, install the CLI with a single command:
+
+```bash
+curl -fsSL https://connect.peridio.com/install.sh | sh
+```
+
+The script detects your operating system and architecture and installs the matching prebuilt binary. To review it before running, open [connect.peridio.com/install.sh](https://connect.peridio.com/install.sh) in your browser.
+
+For Windows, manual installation, the full platform and architecture matrix, and upgrade instructions, see the [Avocado CLI installation guide](/developer-reference/avocado-cli/installation).

--- a/src/docs-guides/getting-started/download.md
+++ b/src/docs-guides/getting-started/download.md
@@ -26,7 +26,7 @@ Download the latest release directly:
 Or install it with [Homebrew](https://brew.sh):
 
 ```bash
-brew install --cask avocado-desktop
+brew install --cask avocado-linux/tap/avocado-desktop
 ```
 
 Once installed, the app updates itself in place, so you do not need to re-download it for new releases.

--- a/src/sidebars-guides.js
+++ b/src/sidebars-guides.js
@@ -10,6 +10,7 @@ const sidebars = {
       collapsed: false,
       items: [
         'getting-started/index',
+        'getting-started/download',
         'getting-started/qemu',
         'getting-started/raspberry-pi',
         'getting-started/jetson',


### PR DESCRIPTION
## Problem

The docs covered installing the Avocado CLI but never the Avocado Desktop app, and no single page pointed a new user at both.

## Solution

Add a "Download & Install" page under Getting Started that covers both products.

## Key changes

- Add `getting-started/download` documenting the macOS desktop DMG, the Homebrew cask, the macOS 13.0+ requirement, and the Windows/Linux "coming soon" state.
- Present the CLI curl one-liner and link to the existing CLI installation guide for the full platform matrix instead of duplicating it.
- Wire the new page into the Getting Started sidebar.

## Reviewer notes

- `npm run build` passes: the new page renders at `/developer-reference/getting-started/download`, appears in the Getting Started sidebar, and its cross-link to the CLI installation guide resolves (Docusaurus fails the build on broken links).
- The install commands (`curl -fsSL https://connect.peridio.com/install.sh | sh` and `brew install --cask avocado-desktop`) are documented, not executed in this change.
- The desktop DMG link points at the current 0.4.4 release; it will need bumping on future desktop releases until the release manifest is served with CORS enabled (tracked separately).
