### PR TITLE
field-notes: publish the agentic development with avocado mcp note

### DIFF
--- a/src/field-notes/2026-07-02-agentic-mcp-pi-exporter.mdx
+++ b/src/field-notes/2026-07-02-agentic-mcp-pi-exporter.mdx
@@ -7,7 +7,6 @@ tags: [raspberrypi4, rust, mcp, agentic, prometheus]
 category: 'Agentic Development'
 image: /img/field-notes/agentic-mcp-pi-exporter-desktop.png
 featured: false
-draft: true # remove once the pi-metrics-exporter reference is pushed to avocado-linux/references
 tested_against: 'Avocado OS 2024.0.140 (2024/edge) on raspberrypi4; pi-metrics-exporter reference; Avocado CLI 0.41.2; Avocado Desktop 0.4.4'
 poster: lreinhardt
 lift_for_blog: 'The gap between "I want a service on my device" and a running, cross-compiled, systemd-managed extension collapses to one plain-English prompt.'


### PR DESCRIPTION
Removes `draft: true` to publish the "Chatting a Prometheus exporter onto a Raspberry Pi 4 with Avocado Desktop" field note.

The `pi-metrics-exporter` reference it links to is now merged to `avocado-linux/references`, so the `avocado init --reference` command and the source links resolve. Verified end to end on a Raspberry Pi 4; the production build passes locally with the note included.
