### PR TITLE
Add 1.0.0-rc.1 ecosystem changelog entry

### DIFF
--- a/src/docs-changelog/july-2026/1.0.0-rc.1.md
+++ b/src/docs-changelog/july-2026/1.0.0-rc.1.md
@@ -1,0 +1,79 @@
+---
+title: '1.0.0-rc.1'
+description: 'Avocado 1.0 release candidate: the declarative build format is stable, Avocado Desktop ships for macOS, and the MCP server gains Connect awareness.'
+---
+
+Avocado 1.0 is a statement about stability, not a feature dump. It marks the
+point where the declarative format that describes how you build, provision, and
+update a device (the `avocado.yaml` contract that everything else is built on) is
+stable and safe to depend on in production. Everything below rolls up under that
+milestone, but each part of the ecosystem keeps its own version and its own pace:
+the CLI, the desktop app, the MCP server, and the hardware and package feeds all
+move independently.
+
+## What 1.0 means
+
+- **The declarative format is stable.** The runtime, extension, and source schema
+  in `avocado.yaml` is frozen for 1.0. Configs you write today keep working across
+  the 1.x line.
+- **It is a release candidate.** `1.0.0-rc.1` exists so you can build against the
+  frozen format and report anything that should block the final tag. Treat it as
+  the shape of 1.0, not the last word.
+- **It is not a list of shiny new features.** Most of what makes 1.0 possible
+  landed across the 0.x line. 1.0 draws the line under that work and says the
+  foundation is ready to sell, ship, and support.
+
+## Avocado CLI: 1.0.0-rc.1
+
+The CLI is the heart of the system, and its 1.0 is about the contract it owns:
+the declarative build format. The capabilities that format now covers matured
+over the 0.x series:
+
+- **Declarative runtimes and extensions.** Describe a device's software set once,
+  then build, image, and install extensions against a runtime sysroot.
+- **`avocado vm` on macOS.** The CLI owns the QEMU lifecycle end to end, with VM
+  hibernation (wake-on-connect, PSCI idle states) and streaming downloads.
+- **Reproducible builds.** Channel snapshot pinning lets a build resolve the same
+  package set later, so a release is reproducible rather than "whatever was on the
+  feed that day."
+- **Private package feeds.** Custom CA / TLS support for pulling from your own
+  feeds.
+- **A top-level `permissions:` block** and **per-step build caching** keyed on
+  input hashes.
+- **`--output json` across the lifecycle**, which is what lets Avocado Desktop
+  drive the CLI programmatically.
+
+Install and upgrade via the Homebrew tap. Linux and Windows builds are in
+progress.
+
+## Avocado Desktop: 1.0
+
+Avocado Desktop is the biggest new surface in this release: a native macOS app
+(Apple Silicon) that puts the whole build-and-deploy loop behind a UI and an AI
+agent.
+
+- **Built-in AI agent.** Describe a project in plain English and the agent
+  scaffolds the extension, cross-compiles it, flashes media, boots the device, and
+  surfaces the result, with no hand-written config to start.
+- **Uses your CLI, or brings its own.** Desktop prefers a host-installed Avocado
+  CLI when one is present and falls back to a bundled sidecar CLI when it is not.
+- **Install via Homebrew** (`brew install --cask`); the DMG is published to the
+  Avocado repo CDN.
+
+## Avocado MCP
+
+The Model Context Protocol server that powers the Desktop agent (and any
+MCP-aware client) now has **Connect awareness**, so an agent can reason about
+Avocado Connect resources alongside local build state. It installs today as a
+one-shot command from GitHub; a package-registry distribution is planned.
+
+## Hardware and package feeds
+
+Avocado's target coverage spans 11 silicon vendors, including NXP, NVIDIA Jetson,
+Qualcomm, Raspberry Pi, and Intel, with more under evaluation. See the
+[hardware support matrix](/hardware/support-matrix) for the current list.
+
+New boards and packages land on channel feeds continuously rather than on a fixed
+release train. A future changelog structure will surface what became available on
+which feed and when; for now, 1.0 marks the platform those feeds build on as
+stable.

--- a/src/docs-changelog/july-2026/1.0.0-rc.1.md
+++ b/src/docs-changelog/july-2026/1.0.0-rc.1.md
@@ -14,8 +14,8 @@ move independently.
 ## What 1.0 means
 
 - **The declarative format is stable.** The runtime, extension, and source schema
-  in `avocado.yaml` is frozen for 1.0. Configs you write today keep working across
-  the 1.x line.
+  in `avocado.yaml` is stable across the 1.x line. Configs you write today keep
+  working as it evolves.
 - **It is a release candidate.** `1.0.0-rc.1` exists so you can build against the
   frozen format and report anything that should block the final tag. Treat it as
   the shape of 1.0, not the last word.
@@ -57,8 +57,8 @@ agent.
   surfaces the result, with no hand-written config to start.
 - **Uses your CLI, or brings its own.** Desktop prefers a host-installed Avocado
   CLI when one is present and falls back to a bundled sidecar CLI when it is not.
-- **Install via Homebrew** (`brew install --cask`); the DMG is published to the
-  Avocado repo CDN.
+- **Install via Homebrew** (`brew install --cask avocado-linux/tap/avocado-desktop`);
+  the DMG is published to the Avocado repo CDN.
 
 ## Avocado MCP
 
@@ -69,8 +69,9 @@ one-shot command from GitHub; a package-registry distribution is planned.
 
 ## Hardware and package feeds
 
-Avocado's target coverage spans 11 silicon vendors, including NXP, NVIDIA Jetson,
-Qualcomm, Raspberry Pi, and Intel, with more under evaluation. See the
+Avocado's target coverage spans 11 hardware vendors, from silicon vendors like
+NXP, NVIDIA, and Qualcomm to board and module makers like Advantech, OnLogic, and
+SolidRun, with more under evaluation. See the
 [hardware support matrix](/hardware/support-matrix) for the current list.
 
 New boards and packages land on channel feeds continuously rather than on a fixed

--- a/src/docs-changelog/latest.mdx
+++ b/src/docs-changelog/latest.mdx
@@ -6,4 +6,4 @@ displayed_sidebar: changelog
 
 import { Redirect } from '@docusaurus/router'
 
-<Redirect to="/changelog/june-2026/0.41.1" />
+<Redirect to="/changelog/july-2026/1.0.0-rc.1" />

--- a/src/sidebars-changelog.js
+++ b/src/sidebars-changelog.js
@@ -5,6 +5,13 @@ const sidebars = {
   changelog: [
     {
       type: 'category',
+      label: 'July 2026',
+      collapsible: false,
+      collapsed: false,
+      items: ['july-2026/1.0.0-rc.1'],
+    },
+    {
+      type: 'category',
       label: 'June 2026',
       collapsible: false,
       collapsed: false,

--- a/src/src/components/ChangelogInfiniteScroll/changelogEntries.js
+++ b/src/src/components/ChangelogInfiniteScroll/changelogEntries.js
@@ -1,5 +1,7 @@
 // Static imports of all changelog entries, ordered newest-first to match sidebars-changelog.js
 
+// -- July 2026 --
+import V1_0_0_RC_1 from '../../../docs-changelog/july-2026/1.0.0-rc.1.md'
 // -- June 2026 --
 import V0_41_1 from '../../../docs-changelog/june-2026/0.41.1.md'
 import V0_41_0 from '../../../docs-changelog/june-2026/0.41.0.md'
@@ -51,6 +53,13 @@ import V0_8_0 from '../../../docs-changelog/september-2025/0.8.0.md'
  * Order matches sidebars-changelog.js exactly.
  */
 export const entries = [
+  {
+    version: '1.0.0-rc.1',
+    monthSlug: 'july-2026',
+    monthLabel: 'July 2026',
+    permalink: '/changelog/july-2026/1.0.0-rc.1',
+    Component: V1_0_0_RC_1,
+  },
   {
     version: '0.41.1',
     monthSlug: 'june-2026',


### PR DESCRIPTION
## Problem

The changelog was CLI-only: every entry was a single Avocado CLI version, so the 1.0 milestone had nowhere to say what it means across the product. Avocado now ships several independently-versioned parts (CLI, Desktop, MCP, and the package feeds), and "what version am I running" no longer has a single answer.

## Solution

Frame 1.0 as a stability statement, not a feature dump. The new entry leads with the declarative `avocado.yaml` format being frozen for the 1.x line, then rolls up Desktop, MCP Connect awareness, and hardware breadth under that milestone, each keeping its own version. This is the narrative step within the existing structure; the date-based navigation restructure lands in a stacked follow-up PR so the release is not gated on a larger IA change.

## Key changes

- Add `src/docs-changelog/july-2026/1.0.0-rc.1.md` with per-component sub-sections (CLI, Desktop, MCP, hardware/feeds).
- Add a July 2026 category to `sidebars-changelog.js`.
- Prepend the entry to `ChangelogInfiniteScroll/changelogEntries.js`.
- Repoint the `latest` redirect to the new entry.

## Reviewer notes

- Built with `make build` (Docusaurus production build): exits 0, route generates at `/changelog/july-2026/1.0.0-rc.1`, `latest` redirects to it, no broken-link warnings.
- Confirm before publishing the final tag: exact CLI tag string (`1.0.0-rc.1`), the MCP tag (left qualitative, no number), the exact Homebrew cask invocation, and the "11 silicon vendors" count against the linked support matrix.
- The scroll component still auto-renders an `h2` version heading above the component sub-headings; that CLI-centric artifact is removed by the follow-up date-nav restructure.
