### PR TITLE
Switch changelog nav from versions to ISO weeks

### DIFF
--- a/src/docs-changelog/2026-w28.md
+++ b/src/docs-changelog/2026-w28.md
@@ -1,5 +1,5 @@
 ---
-title: '1.0.0-rc.1'
+title: 'Jul 6-12, 2026'
 description: 'Avocado 1.0 release candidate: the declarative build format is stable, Avocado Desktop ships for macOS, and the MCP server gains Connect awareness.'
 ---
 

--- a/src/docs-changelog/latest.mdx
+++ b/src/docs-changelog/latest.mdx
@@ -6,4 +6,4 @@ displayed_sidebar: changelog
 
 import { Redirect } from '@docusaurus/router'
 
-<Redirect to="/changelog/july-2026/1.0.0-rc.1" />
+<Redirect to="/changelog/2026-w28" />

--- a/src/docs-changelog/latest.mdx
+++ b/src/docs-changelog/latest.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Latest'
-description: 'The latest Avocado CLI release.'
+description: 'The latest Avocado ecosystem changelog entry.'
 displayed_sidebar: changelog
 ---
 

--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -92,6 +92,9 @@ const config = {
         routeBasePath: 'changelog',
         sidebarPath: require.resolve('./sidebars-changelog.js'),
         breadcrumbs: true,
+        // Weekly entries are named YYYY-wNN; without this the number-prefix
+        // parser strips the leading year and collapses the doc id to wNN.
+        numberPrefixParser: false,
       },
     ],
     [

--- a/src/sidebars-changelog.js
+++ b/src/sidebars-changelog.js
@@ -8,7 +8,7 @@ const sidebars = {
       label: 'July 2026',
       collapsible: false,
       collapsed: false,
-      items: ['july-2026/1.0.0-rc.1'],
+      items: ['2026-w28'],
     },
     {
       type: 'category',

--- a/src/src/components/ChangelogInfiniteScroll/changelogEntries.js
+++ b/src/src/components/ChangelogInfiniteScroll/changelogEntries.js
@@ -1,7 +1,7 @@
 // Static imports of all changelog entries, ordered newest-first to match sidebars-changelog.js
 
 // -- July 2026 --
-import V1_0_0_RC_1 from '../../../docs-changelog/july-2026/1.0.0-rc.1.md'
+import W2026_28 from '../../../docs-changelog/2026-w28.md'
 // -- June 2026 --
 import V0_41_1 from '../../../docs-changelog/june-2026/0.41.1.md'
 import V0_41_0 from '../../../docs-changelog/june-2026/0.41.0.md'
@@ -54,11 +54,12 @@ import V0_8_0 from '../../../docs-changelog/september-2025/0.8.0.md'
  */
 export const entries = [
   {
-    version: '1.0.0-rc.1',
+    version: '2026-w28',
+    weekLabel: 'Jul 6-12, 2026',
     monthSlug: 'july-2026',
     monthLabel: 'July 2026',
-    permalink: '/changelog/july-2026/1.0.0-rc.1',
-    Component: V1_0_0_RC_1,
+    permalink: '/changelog/2026-w28',
+    Component: W2026_28,
   },
   {
     version: '0.41.1',

--- a/src/src/components/ChangelogInfiniteScroll/index.js
+++ b/src/src/components/ChangelogInfiniteScroll/index.js
@@ -154,7 +154,7 @@ export default function ChangelogInfiniteScroll({ initialContent }) {
     }
     const activeEntry = entries.find((e) => e.permalink === activePermalink)
     if (activeEntry) {
-      document.title = `${activeEntry.version} | Changelog`
+      document.title = `${activeEntry.weekLabel || activeEntry.version} | Changelog`
     }
 
     const sidebar = document.querySelector('[class*="docSidebarContainer"]')
@@ -253,7 +253,7 @@ export default function ChangelogInfiniteScroll({ initialContent }) {
               >
                 {isNewMonth && <div className={styles.monthLabel}>{entry.monthLabel}</div>}
                 <Heading as="h2" className={styles.versionHeading}>
-                  {entry.version}
+                  {entry.weekLabel || entry.version}
                 </Heading>
                 <div className="theme-doc-markdown markdown">
                   <entry.Component />


### PR DESCRIPTION
Stacked on #445. Review/merge that first; this PR's base is `jtia/changelog-1.0` and will be retargeted to `main` once #445 lands.

## Problem

The changelog used one entry per CLI version, so a release where the CLI, Desktop, MCP, and package feeds each move at their own cadence had nowhere to live. A version number in the left column implies a single "Avocado version," which does not exist.

## Solution

Make the ISO week the primary entry. The left nav lists weeks under month headers (Justin's week granularity, Kristen's month scannability), and each week's body carries per-component sections that keep their own version numbers. The scroll feed renders the week label instead of a version heading, falling back to the version for historical entries not yet migrated. This applies the new model going forward only; the ~40 historical version entries are migrated in a follow-up PR.

## Key changes

- Add `src/docs-changelog/2026-w28.md`; the 1.0 narrative from #445 becomes the first week bucket.
- Left nav (`sidebars-changelog.js`) lists the week under a July 2026 header; historical months/versions unchanged below.
- `ChangelogInfiniteScroll` renders `weekLabel || version` for heading and title; entries array gains a `weekLabel`.
- Disable `numberPrefixParser` for the changelog plugin so `YYYY-wNN` doc ids keep the leading year.
- Repoint `latest` to the week entry.

## Reviewer notes

- Built with `make build`: exits 0, `/changelog/2026-w28` generates, `latest` redirects to it, historical version routes (e.g. `/changelog/june-2026/0.41.1`) are unchanged, no broken-link warnings.
- The follow-up PR migrates the historical version entries into weekly buckets and drops the `version` fallback once none remain.
- Colored per-product chips are intentionally left to a design pass; per-component headings carry the product label for now.
