### PR TITLE
docs: document --connect-sign signing-key prerequisite

### DIFF
--- a/src/docs-guides/avocado-cli/commands.md
+++ b/src/docs-guides/avocado-cli/commands.md
@@ -97,6 +97,7 @@ Options:
   -d, --device <DEVICE>                 Device to deploy to as [user@]host[:port] (e.g. root@192.168.1.100:2222)
       --container-arg <CONTAINER_ARGS>  Additional arguments to pass to the container runtime
       --dnf-arg <DNF_ARGS>              Additional arguments to pass to DNF commands
+      --connect-sign                    Sign TUF metadata via Avocado Connect instead of locally (use for a device that has taken a Connect OTA). Requires a local signing key configured for the runtime (Level 2: signing.key + `avocado connect trust promote-root`); without one no root.json is baked and the deploy fails during Phase 1 hash collection.
       --runs-on <USER@HOST>             Run command on remote host using local volume via NFS (format: user@host)
       --nfs-port <NFS_PORT>             NFS port for remote execution (auto-selects from 12050-12099 if not specified)
       --sdk-arch <ARCH>                 SDK container architecture for cross-arch emulation via Docker buildx/QEMU (aarch64 or x86-64)
@@ -1467,6 +1468,7 @@ Options:
   -d, --device <DEVICE>                 Device to deploy to as [user@]host[:port] (e.g. root@192.168.1.100:2222)
       --container-arg <CONTAINER_ARGS>  Additional arguments to pass to the container runtime
       --dnf-arg <DNF_ARGS>              Additional arguments to pass to DNF commands
+      --connect-sign                    Sign TUF metadata via Avocado Connect instead of locally (use for a device that has taken a Connect OTA). Requires a local signing key configured for the runtime (Level 2: signing.key + `avocado connect trust promote-root`); without one no root.json is baked and the deploy fails during Phase 1 hash collection.
       --runs-on <USER@HOST>             Run command on remote host using local volume via NFS (format: user@host)
       --nfs-port <NFS_PORT>             NFS port for remote execution (auto-selects from 12050-12099 if not specified)
       --sdk-arch <ARCH>                 SDK container architecture for cross-arch emulation via Docker buildx/QEMU (aarch64 or x86-64)

--- a/src/docs-guides/avocado-cli/commands.md
+++ b/src/docs-guides/avocado-cli/commands.md
@@ -97,7 +97,7 @@ Options:
   -d, --device <DEVICE>                 Device to deploy to as [user@]host[:port] (e.g. root@192.168.1.100:2222)
       --container-arg <CONTAINER_ARGS>  Additional arguments to pass to the container runtime
       --dnf-arg <DNF_ARGS>              Additional arguments to pass to DNF commands
-      --connect-sign                    Sign TUF metadata via Avocado Connect instead of locally (use for a device that has taken a Connect OTA). Requires a local signing key configured for the runtime (Level 2: signing.key + `avocado connect trust promote-root`); without one no root.json is baked and the deploy fails during Phase 1 hash collection.
+      --connect-sign                    Sign TUF metadata via Avocado Connect instead of locally (use for a device that has taken a Connect OTA). Requires a local signing key configured for the runtime (Level 2: signing.key + avocado connect trust promote-root --key <KEY>); without one no root.json is baked and the deploy fails during Phase 1 hash collection.
       --runs-on <USER@HOST>             Run command on remote host using local volume via NFS (format: user@host)
       --nfs-port <NFS_PORT>             NFS port for remote execution (auto-selects from 12050-12099 if not specified)
       --sdk-arch <ARCH>                 SDK container architecture for cross-arch emulation via Docker buildx/QEMU (aarch64 or x86-64)
@@ -1468,7 +1468,7 @@ Options:
   -d, --device <DEVICE>                 Device to deploy to as [user@]host[:port] (e.g. root@192.168.1.100:2222)
       --container-arg <CONTAINER_ARGS>  Additional arguments to pass to the container runtime
       --dnf-arg <DNF_ARGS>              Additional arguments to pass to DNF commands
-      --connect-sign                    Sign TUF metadata via Avocado Connect instead of locally (use for a device that has taken a Connect OTA). Requires a local signing key configured for the runtime (Level 2: signing.key + `avocado connect trust promote-root`); without one no root.json is baked and the deploy fails during Phase 1 hash collection.
+      --connect-sign                    Sign TUF metadata via Avocado Connect instead of locally (use for a device that has taken a Connect OTA). Requires a local signing key configured for the runtime (Level 2: signing.key + avocado connect trust promote-root --key <KEY>); without one no root.json is baked and the deploy fails during Phase 1 hash collection.
       --runs-on <USER@HOST>             Run command on remote host using local volume via NFS (format: user@host)
       --nfs-port <NFS_PORT>             NFS port for remote execution (auto-selects from 12050-12099 if not specified)
       --sdk-arch <ARCH>                 SDK container architecture for cross-arch emulation via Docker buildx/QEMU (aarch64 or x86-64)


### PR DESCRIPTION
## Problem

Follow-up to avocado-cli #158 (raised by @lee-reinhardt). The CLI command
reference did not list `--connect-sign`, and the flag carries a non-obvious
prerequisite: it requires a **local signing key** configured for the runtime
(Level 2). Without one, no `root.json` is baked and `avocado deploy
--connect-sign` fails during Phase 1 hash collection with a bare "No root.json
found".

## Change

Add the `--connect-sign` option to the `avocado deploy` and `avocado runtime
deploy` entries in `src/docs-guides/avocado-cli/commands.md`, with the
signing-key prerequisite spelled out. Pairs with avocado-cli #172 (which adds
the same note to the CLI help + Phase 1 error).

## Verification note

The added line is inert text inside a fenced code block (no MDX/JSX/links), so
it cannot affect the Docusaurus build; I did not run `yarn build` locally
(node_modules not installed in this checkout). The `--connect-sign` help text
mirrors the merged CLI flag rather than a captured `--help` run.