### PR TITLE
Document stale-volume build recovery in the QEMU guide

### DIFF
--- a/src/docs-guides/getting-started/qemu.md
+++ b/src/docs-guides/getting-started/qemu.md
@@ -44,7 +44,7 @@ avocado build
 
 ### Troubleshooting a stale build volume
 
-If `avocado build` fails during `runtime build dev` with a missing `/etc/passwd` (or `/etc/shadow` / `/etc/group`) under `rootfs-work`, the build volume is stale or half-populated. This happens when a previous install was interrupted, or when a project directory was deleted by hand instead of with `avocado clean` - the per-project Docker volume outlives the folder.
+If `avocado build` fails during `runtime build dev` with a missing `/etc/passwd` (or `/etc/shadow` / `/etc/group`) under `rootfs-work`, the build volume is stale or half-populated. This happens when a previous install was interrupted, or when a project directory was deleted by hand instead of with `avocado clean`. The per-project Docker volume outlives the folder.
 
 Reset the build state and rebuild:
 
@@ -55,7 +55,7 @@ avocado install -f
 avocado build
 ```
 
-`avocado clean` drops the current project's volume; `avocado prune` clears abandoned volumes left behind by deleted projects. Run both - `clean` alone may not clear an abandoned volume that is shadowing the build.
+`avocado clean` drops the current project's volume; `avocado prune` clears abandoned volumes left behind by deleted projects. Run both, since `clean` alone may not clear an abandoned volume that is shadowing the build.
 
 ## Provision
 

--- a/src/docs-guides/getting-started/qemu.md
+++ b/src/docs-guides/getting-started/qemu.md
@@ -44,7 +44,7 @@ avocado build
 
 ### Troubleshooting a stale build volume
 
-If `avocado build` fails during `runtime build dev` with a missing `/etc/passwd` (or `/etc/shadow` / `/etc/group`) under `rootfs-work`, the build volume is stale or half-populated. This happens when a previous install was interrupted, or when a project directory was deleted by hand instead of with `avocado clean`. The per-project Docker volume outlives the folder.
+If `avocado build` fails during `runtime build dev` with a missing `/etc/passwd` (or `/etc/shadow` / `/etc/group`) under `rootfs-work`, the build volume is stale or half-populated. This happens when a previous install was interrupted, or when a project directory was deleted manually without first running `avocado clean`. The per-project Docker volume outlives the folder.
 
 Reset the build state and rebuild:
 

--- a/src/docs-guides/getting-started/qemu.md
+++ b/src/docs-guides/getting-started/qemu.md
@@ -42,6 +42,21 @@ Build the system image — this compiles extensions and assembles the runtime.
 avocado build
 ```
 
+### Troubleshooting a stale build volume
+
+If `avocado build` fails during `runtime build dev` with a missing `/etc/passwd` (or `/etc/shadow` / `/etc/group`) under `rootfs-work`, the build volume is stale or half-populated. This happens when a previous install was interrupted, or when a project directory was deleted by hand instead of with `avocado clean` - the per-project Docker volume outlives the folder.
+
+Reset the build state and rebuild:
+
+```bash
+avocado clean
+avocado prune
+avocado install -f
+avocado build
+```
+
+`avocado clean` drops the current project's volume; `avocado prune` clears abandoned volumes left behind by deleted projects. Run both - `clean` alone may not clear an abandoned volume that is shadowing the build.
+
 ## Provision
 
 Provision creates the bootable disk image for the `dev` runtime. Because QEMU is virtual, the provisioning artifacts are written to disk on your development machine rather than flashed to hardware.


### PR DESCRIPTION
## Problem

A user following the QEMU getting-started guide hit `avocado build` failing during `runtime build dev` with a missing `/etc/passwd` under `rootfs-work`. The cause was a stale, half-populated build volume, but the guide offered no recovery path, so the failure read like a broken release.

## Solution

Add a troubleshooting subsection to the QEMU guide that names the symptom and gives the reset.

## Key changes

- New "Troubleshooting a stale build volume" section with the `clean` + `prune` + reinstall recovery.
- Notes that `avocado clean` alone can be insufficient (it only drops the active project's volume); `avocado prune` clears abandoned volumes that can shadow a build.

## Reviewer notes

- `npm run build` passes; the section is plain GFM (heading + bash block), no MDX components or new links.
- Companion CLI fix (friendlier build error + auto-reap of abandoned volumes) is a separate avocado-linux/avocado-cli PR.
