### PR TITLE
fix: make image lightbox overlay visible in production build

### DIFF
--- a/src/field-notes/2026-07-01-nodejs-dashboard-portability.mdx
+++ b/src/field-notes/2026-07-01-nodejs-dashboard-portability.mdx
@@ -107,11 +107,11 @@ Follow the USB disconnect/reconnect prompts for the Tegra flash. `armv8a_tegra23
 
 ![The nodejs-dashboard running unchanged on qemux86-64, a Jetson Orin Nano, and a Raspberry Pi 5 at the same time.](/img/field-notes/nodejs-dashboard-portability.png)
 
-<p style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
+<div style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
   One source tree, three targets, live at once: QEMU (x86-64), Jetson Orin Nano (Tegra Arm64), and
   Raspberry Pi 5 (Broadcom Arm64). Same <code>app/</code> source, three architectures serving it
   simultaneously.
-</p>
+</div>
 
 <PullQuote label="code change between targets">
   Only **one line** code change between the QEMU run and the Jetson run

--- a/src/field-notes/2026-07-02-agentic-mcp-pi-exporter.mdx
+++ b/src/field-notes/2026-07-02-agentic-mcp-pi-exporter.mdx
@@ -35,10 +35,10 @@ Avocado Desktop is the local tool that builds and provisions Avocado OS, Peridio
 
 ![Avocado Desktop, with the build VM and live metrics in the main pane and the agent chat on the right.](/img/field-notes/agentic-mcp-pi-exporter-desktop.png)
 
-<p style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
+<div style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
   Avocado Desktop. The build VM and live metrics fill the main pane; the{' '}
   <strong>agent panel</strong> on the right is where the whole note happens.
-</p>
+</div>
 
 This note is one run of that loop end to end. I described what I wanted in a single message and the agent produced a real Avocado extension that cross-compiled to aarch64 and booted on the board with the service already running. The point is not the exporter; it is that config, cross-compilation, packaging, and a first-boot systemd service all came out of the chat, and I never had to know an Avocado config key.
 
@@ -57,11 +57,11 @@ examples for Avocado, use them as a guide.
 
 ![The agent panel: the prompt, then the agent listing projects, cloning the references repo, and finding rust-vitals on its own.](/img/field-notes/agentic-mcp-pi-exporter-chat.png)
 
-<p style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
+<div style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
   From that one prompt: the agent lists projects, clones the Avocado references repo, greps for
   Rust, and finds <code>rust-vitals</code> itself, then starts mirroring it. You type in the chat;
   it calls the Avocado MCP to run the toolchain.
-</p>
+</div>
 
 ## What the agent produced
 
@@ -121,11 +121,11 @@ dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux
 
 ![The agent's summary of the extension it created and built.](/img/field-notes/agentic-mcp-pi-exporter-result.png)
 
-<p style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
+<div style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
   The agent's own summary: the <code>avocado.yaml</code>, the Rust app, the cross-compile scripts,
   and the systemd service, all generated from the prompt. It notes the project "follows the
   rust-vitals reference structure."
-</p>
+</div>
 
 <PullQuote>
   From one plain-English prompt to a **cross-compiled aarch64 extension** that systemd auto-started
@@ -144,21 +144,21 @@ avocado provision -r dev --profile sd
 
 ![Avocado Desktop's Provision step writing the bootable SD card.](/img/field-notes/agentic-mcp-pi-exporter-provision.png)
 
-<p style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
+<div style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
   The Provision step: the <code>raspberrypi4</code> target and the <code>sd</code> profile writing
   the bootable card. "USB passthrough ready" lets Avocado Desktop write the SD directly.
-</p>
+</div>
 
 The `sd` profile produced a bootable image and wrote it to the SD card. I moved the card to the Pi 4, attached a USB-UART cable at 115200 baud, and powered on. It booted through U-Boot into Avocado OS, and the extension's `pi-metrics.service` was already running.
 
 ![The booted Pi in Avocado Desktop's serial monitor, with pi-metrics.service running.](/img/field-notes/agentic-mcp-pi-exporter-boot.png)
 
-<p style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
+<div style={{ textAlign: 'center', fontSize: '0.85rem', opacity: 0.7 }}>
   The freshly booted Pi over Avocado Desktop's built-in serial monitor:{' '}
   <code>pi-metrics.service</code> is active and listening on <code>0.0.0.0:9100</code>, and{' '}
   <code>eth0</code> reports <code>192.168.1.88</code> - the same address I curl from my laptop
   below.
-</p>
+</div>
 
 From my laptop, against the Pi's DHCP address:
 

--- a/src/src/css/custom.css
+++ b/src/src/css/custom.css
@@ -1361,7 +1361,13 @@ html[data-theme="dark"] .plugin-id-field-notes {
   touch-action: none;
 }
 
-.img-lightbox--open {
+/* Compound selector (not a plain `.img-lightbox--open`) so this rule outranks
+   the base `.img-lightbox` by specificity. cssnano merges rules with identical
+   declarations and can hoist a single-class `--open` rule above the base rule,
+   inverting the equal-specificity cascade and leaving the overlay hidden in the
+   production build (works in dev, where CSS is unminified). Higher specificity
+   makes the reveal win regardless of source order. */
+.img-lightbox.img-lightbox--open {
   opacity: 1;
   visibility: visible;
 }


### PR DESCRIPTION
## Problem

On the production docs site, clicking a field-note image to open the full-size viewer does nothing. It works in local dev (`docusaurus start`). A minified React error #418 also appears in the console on those pages.

## Root cause (two separate bugs)

**Lightbox never becomes visible (the reported symptom).** The click handler fires and adds the `img-lightbox--open` class, but the overlay's computed style stays `opacity: 0; visibility: hidden`, so nothing appears. In the minified production CSS, cssnano's "merge rules with identical declarations" optimization hoists the single-class `.img-lightbox--open { opacity: 1; visibility: visible }` up next to the navbar-sidebar rules that share those declarations, placing it before the base `.img-lightbox` rule. Both selectors are single-class (equal specificity), so source order decides, and the later base rule (`opacity: 0; visibility: hidden`) wins. Dev is unminified, so source order holds and it works there.

**React hydration error #418.** Field-note captions were authored as a raw `<p style={{...}}>` with multi-line children. MDX re-parses the indented content as a markdown paragraph, emitting a `<p>` nested inside a `<p>` — invalid HTML that the browser reparents, diverging the SSR DOM from React's tree. This does not break the lightbox, but it is a real correctness issue on the same pages.

## Fix

- CSS: give the reveal rule higher specificity (`.img-lightbox.img-lightbox--open`) so it wins regardless of how the minifier reorders equal-specificity rules.
- MDX: change the caption wrappers from `<p>` to `<div>` so the MDX-generated inner `<p>` nests validly (`<div><p>...</p></div>`).

## Verification

Drove a headless browser (dispatched real mouse clicks) against a local production build and the live site:

- Before (live + local prod build): the overlay opens but computes `opacity: 0` / `visibility: hidden`; #418 present.
- After (local prod build): a real click opens a visible overlay (`opacity: 1` / `visibility: visible`); no #418.

The CSS fix resolves the lightbox on every field note, not just the two edited for the caption change.
