### PR TITLE
fix: use avocadoctl in DeepStream field note verify step

### DIFF
--- a/src/field-notes/2026-06-22-fastest-path-ai-vision-nvidia.mdx
+++ b/src/field-notes/2026-06-22-fastest-path-ai-vision-nvidia.mdx
@@ -216,7 +216,7 @@ ssh root@<device-ip>
 Runtime and service are up:
 
 ```bash
-avocado control runtime list   # the dev runtime is running
+avocadoctl runtime list        # the dev runtime is running
 systemctl status vision-app    # Active: active (running)
 ```
 


### PR DESCRIPTION
## Problem

The NVIDIA DeepStream field note's "Testing the reference → Verify" step uses the wrong command:

```bash
avocado control runtime list   # the dev runtime is running
```

The on-device runtime control command is `avocadoctl`, not `avocado control` (`avocado-control` is the GitHub source repo name; the binary is `avocadoctl`). Reported from Discord.

## Fix

Change it to `avocadoctl runtime list`. Single occurrence; every other reference in the docs already uses `avocadoctl`.
