### PR TITLE
Docs legal hardening: footer, Terms of Use, Disclaimer, and accurate privacy statement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Description
+
+<!-- What does this PR change, and why? -->
+
+## Checklist
+
+- [ ] I have read the [Contributing guidelines](../CONTRIBUTING.md).
+- [ ] I have the right to submit this contribution, and I agree it is licensed to
+      Peridio, Inc. as described in the Contributing guidelines.
+- [ ] This contribution contains no third-party personal data and nothing
+      defamatory, infringing, or unlawful.
+- [ ] I ran the project checks (`bash scripts/checks.sh`) and they pass.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+Thanks for helping improve the Avocado OS documentation.
+
+## How to contribute
+
+- The documentation site lives in `src/`. See the [README](./README.md) for
+  local setup and how to run the site.
+- Open a pull request against `main`. Keep changes focused and describe what you
+  changed and why.
+- Before submitting, please run the project checks and make sure they pass:
+
+  ```bash
+  bash scripts/checks.sh
+  ```
+
+  This lints, checks formatting, and builds the site — the same checks CI runs.
+
+## Licensing of contributions
+
+This project is owned by Peridio, Inc. and is provided under the terms in
+[LICENSE](./LICENSE).
+
+By submitting a contribution (a pull request, patch, text, image, or any other
+material) for inclusion in this project, you agree that:
+
+- **License grant.** You grant Peridio, Inc. a perpetual, worldwide,
+  non-exclusive, royalty-free, irrevocable license to use, reproduce, modify,
+  adapt, publish, distribute, and display your contribution as part of this
+  project and the Avocado OS documentation, including the right to license it
+  under the project's terms.
+- **Right to contribute.** Your contribution is your original work, or you
+  otherwise have the right to submit it, and submitting it does not violate any
+  third party's rights or any agreement or law that applies to you.
+- **No third-party personal data.** Your contribution does not contain personal
+  information about any third party.
+- **Nothing unlawful.** Your contribution is not defamatory, misleading,
+  infringing, or otherwise unlawful.
+
+Please do not submit anything you do not have the right to license this way.
+
+## Editorial discretion
+
+Peridio has sole editorial discretion over the content published on the
+documentation site. We may modify, decline, remove, or revert any contribution
+at any time.
+
+## Reporting a problem
+
+- **Security vulnerabilities:** please do **not** open a public issue or pull
+  request. Report them privately to community@avocadolinux.org.
+- **Improper content** (for example, material you believe is infringing, contains
+  personal information, or otherwise should not appear): email
+  community@avocadolinux.org and we will review it.

--- a/src/docs-overview/policies/disclaimer.md
+++ b/src/docs-overview/policies/disclaimer.md
@@ -1,0 +1,56 @@
+---
+title: Disclaimer
+sidebar_position: 3
+description: Disclaimer for the Avocado OS documentation
+slug: disclaimer
+---
+
+## Documentation provided "as is"
+
+This documentation is provided for informational purposes only, on an **"as is"
+and "as available" basis, without warranties or conditions of any kind**,
+whether express or implied, including but not limited to warranties of
+merchantability, fitness for a particular purpose, accuracy, or
+non-infringement.
+
+We work to keep this documentation accurate and up to date, but we do not
+guarantee that it is complete, current, or error-free. Product behavior,
+commands, hardware support, and interfaces may change, and the documentation may
+lag behind those changes.
+
+## Procedures can be destructive
+
+Some procedures described here — including, but not limited to, **flashing media
+(SD / USB / NVMe), provisioning devices, and deploying or updating software on
+hardware** — can permanently erase data or render a device inoperable if
+performed incorrectly or on the wrong target.
+
+Before following such a procedure, you are responsible for:
+
+- Reading the full procedure and understanding what each step does.
+- Confirming you are acting on the correct device, media, or target.
+- Backing up any data you cannot afford to lose.
+- Verifying commands before you run them, especially those run with elevated
+  privileges.
+
+## Limitation of liability
+
+To the maximum extent permitted by applicable law, Peridio, Inc. and its
+contributors are **not liable for any loss or damage** — including, without
+limitation, lost data, damaged or inoperable hardware, downtime, or any direct,
+indirect, incidental, special, or consequential damages — arising out of or in
+connection with the use of, or reliance on, this documentation.
+
+## Third-party tools and hardware
+
+This documentation may reference third-party hardware, software, and services.
+Those are governed by their own terms and warranties. We make no representations
+about, and accept no responsibility for, third-party products or content.
+
+## Your responsibility
+
+You are responsible for how you use this documentation and for the outcomes of
+any procedure you choose to perform. Your use of this documentation is also
+governed by our
+[Terms &amp; Conditions](https://console.peridio.com/policy/tos) and
+[Privacy Statement](/privacy).

--- a/src/docs-overview/policies/disclaimer.md
+++ b/src/docs-overview/policies/disclaimer.md
@@ -52,5 +52,5 @@ about, and accept no responsibility for, third-party products or content.
 You are responsible for how you use this documentation and for the outcomes of
 any procedure you choose to perform. Your use of this documentation is also
 governed by our
-[Terms of Use](/terms) and
-[Privacy Statement](/privacy).
+[Terms of Use](/policies/terms) and
+[Privacy Statement](/policies/privacy).

--- a/src/docs-overview/policies/disclaimer.md
+++ b/src/docs-overview/policies/disclaimer.md
@@ -1,6 +1,6 @@
 ---
 title: Disclaimer
-sidebar_position: 3
+sidebar_position: 4
 description: Disclaimer for the Avocado OS documentation
 slug: disclaimer
 ---
@@ -52,5 +52,5 @@ about, and accept no responsibility for, third-party products or content.
 You are responsible for how you use this documentation and for the outcomes of
 any procedure you choose to perform. Your use of this documentation is also
 governed by our
-[Terms &amp; Conditions](https://console.peridio.com/policy/tos) and
+[Terms of Use](/terms) and
 [Privacy Statement](/privacy).

--- a/src/docs-overview/policies/privacy.md
+++ b/src/docs-overview/policies/privacy.md
@@ -11,18 +11,35 @@ Avocado Linux is committed to protecting your privacy. This Privacy Statement ex
 
 ## Information we collect
 
-**We do not collect any personal data from users of our documentation site or software.**
+We do not require you to create an account, and we do not ask you to provide
+personal information in order to read this documentation.
 
-Specifically:
+We do, however, use analytics to understand how this documentation site is used
+(see below), which collects certain information automatically.
 
-- We do not create or require user accounts
-- We do not collect personal information
-- We do not store IP addresses
-- We do not log usage information
+## Analytics and cookies
+
+This documentation site uses **Google Analytics**, a web analytics service
+provided by Google, to help us understand how visitors use the site so we can
+improve it. Google Analytics uses cookies and similar technologies and may
+collect information automatically, including:
+
+- Pages visited and interactions with the site
+- Approximate location derived from your IP address
+- Device, browser, and operating-system information
+- Referring pages and general usage patterns
+
+This information is processed by Google on our behalf in accordance with
+[Google's Privacy Policy](https://policies.google.com/privacy) and
+[how Google uses data from sites that use its services](https://policies.google.com/technologies/partner-sites).
+You can opt out of Google Analytics across sites using Google's
+[opt-out browser add-on](https://tools.google.com/dlpage/gaoptout), and you can
+manage or block cookies through your browser settings.
 
 ## Third-Party Services
 
-Our documentation is hosted on Github, which may maintain standard server logs for security and maintenance purposes. These logs are not accessed or used by the Avocado Linux project team.
+Our documentation is hosted on GitHub, which may maintain standard server logs
+for security and maintenance purposes.
 
 ## Changes to this privacy statement
 
@@ -32,4 +49,4 @@ If we decide to change our privacy practices, we will post those changes to this
 
 If you have any questions about this Privacy Statement, please contact us at community@avocadolinux.org.
 
-Last updated: 2025-03
+Last updated: 2026-07

--- a/src/docs-overview/policies/privacy.md
+++ b/src/docs-overview/policies/privacy.md
@@ -1,13 +1,16 @@
 ---
 title: Privacy Statement
-sidebar_position: 2
-description: Privacy Statement for Avocado Linux
+sidebar_position: 3
+description: Privacy Statement for the Avocado OS documentation site
 slug: privacy
 ---
 
 ## Our Commitment to Privacy
 
-Avocado Linux is committed to protecting your privacy. This Privacy Statement explains our data practices regarding the information we collect.
+Peridio, Inc. ("Peridio", "we", "us") operates the Avocado OS documentation site
+and is committed to protecting your privacy. Avocado OS and the Avocado Linux
+project are owned and operated by Peridio. This Privacy Statement explains our
+data practices regarding the information we collect.
 
 ## Information we collect
 
@@ -39,7 +42,8 @@ manage or block cookies through your browser settings.
 ## Third-Party Services
 
 Our documentation is hosted on GitHub, which may maintain standard server logs
-for security and maintenance purposes.
+for security and maintenance purposes. These logs are not accessed or used by
+Peridio.
 
 ## Changes to this privacy statement
 

--- a/src/docs-overview/policies/terms.md
+++ b/src/docs-overview/policies/terms.md
@@ -9,8 +9,8 @@ slug: terms
 
 These Terms of Use ("Terms") govern your access to and use of the Avocado OS
 documentation website at docs.peridio.com (the "Site"), operated by
-Peridio, Inc. ("Peridio", "we", "us"). Avocado OS and the Avocado Linux project
-are owned and operated by Peridio. By accessing or using the Site, you agree to
+Peridio, Inc., a Delaware corporation ("Peridio", "we", "us"). Avocado OS and the
+Avocado Linux project are owned and operated by Peridio. By accessing or using the Site, you agree to
 these Terms. If you do not agree, do not use the Site.
 
 ## The Site is documentation
@@ -76,6 +76,11 @@ collected and how it is used.
 
 We may update these Terms from time to time. Changes take effect when posted on
 this page, and your continued use of the Site means you accept the updated Terms.
+
+## Governing law
+
+These Terms are governed by the laws of the State of Delaware, United States,
+without regard to its conflict-of-laws principles.
 
 ## Contact us
 

--- a/src/docs-overview/policies/terms.md
+++ b/src/docs-overview/policies/terms.md
@@ -56,7 +56,7 @@ You agree not to:
 
 The Site and its content are provided on an "as is" and "as available" basis,
 without warranties or conditions of any kind, express or implied. See our
-[Disclaimer](/disclaimer) for details, including the risks of following
+[Disclaimer](/policies/disclaimer) for details, including the risks of following
 procedures that can modify or damage devices and data.
 
 ## Limitation of liability
@@ -75,8 +75,9 @@ content and do not endorse it by linking to it.
 
 ## Privacy
 
-Your use of the Site is also subject to our [Privacy Statement](/privacy), which
-explains what information is collected and how it is used.
+Your use of the Site is also subject to our
+[Privacy Statement](/policies/privacy), which explains what information is
+collected and how it is used.
 
 ## Changes to these terms
 

--- a/src/docs-overview/policies/terms.md
+++ b/src/docs-overview/policies/terms.md
@@ -1,0 +1,96 @@
+---
+title: Terms of Use
+sidebar_position: 2
+description: Terms of Use for the Avocado OS documentation site
+slug: terms
+---
+
+<!--
+  REVIEW BEFORE MERGE:
+  - Governing-law jurisdiction is a placeholder ([STATE]) — confirm with counsel.
+  - Code-sample reuse stance (see "Intellectual property") — confirm the intended
+    license for code samples.
+  - Confirm the legal entity ("Peridio, Inc.") and contact address.
+-->
+
+## Acceptance of these terms
+
+These Terms of Use ("Terms") govern your access to and use of the Avocado OS
+documentation website at docs.peridio.com (the "Site"), operated by
+Peridio, Inc. ("Peridio", "we", "us"). Avocado OS and the Avocado Linux project
+are owned and operated by Peridio. By accessing or using the Site, you agree to
+these Terms. If you do not agree, do not use the Site.
+
+## The Site is documentation
+
+The Site provides technical documentation for informational purposes. It does
+not create any support, service, or contractual relationship, and nothing on the
+Site is a warranty or guarantee about any product, service, or outcome.
+
+## Intellectual property
+
+Except where otherwise noted, the content on the Site — including text, graphics,
+logos, and the arrangement of that content — is owned by Peridio or its licensors
+and is protected by intellectual-property laws. "Peridio" and "Avocado OS", and
+associated logos, are trademarks of Peridio; nothing here grants you a right to
+use them.
+
+You may view and print pages of the Site for your own reference. Unless a page or
+file states otherwise, **code samples in the documentation may be used in your
+own projects.** You may not otherwise copy, republish, or redistribute the
+Site's content, or remove any copyright or proprietary notices, without our
+permission.
+
+## Acceptable use
+
+You agree not to:
+
+- use the Site in violation of any applicable law;
+- attempt to disrupt, damage, overload, or gain unauthorized access to the Site
+  or its infrastructure;
+- scrape, harvest, or bulk-download the Site in a way that burdens it or
+  circumvents access controls; or
+- misrepresent the Site's content or use it in a misleading way.
+
+## Disclaimer of warranties
+
+The Site and its content are provided on an "as is" and "as available" basis,
+without warranties or conditions of any kind, express or implied. See our
+[Disclaimer](/disclaimer) for details, including the risks of following
+procedures that can modify or damage devices and data.
+
+## Limitation of liability
+
+To the maximum extent permitted by applicable law, Peridio and its contributors
+are not liable for any loss or damage — including lost data, damaged or
+inoperable hardware, downtime, or any direct, indirect, incidental, special, or
+consequential damages — arising out of or in connection with your use of, or
+reliance on, the Site.
+
+## Third-party links
+
+The Site may link to third-party websites, hardware, software, and services,
+which are governed by their own terms. We are not responsible for third-party
+content and do not endorse it by linking to it.
+
+## Privacy
+
+Your use of the Site is also subject to our [Privacy Statement](/privacy), which
+explains what information is collected and how it is used.
+
+## Changes to these terms
+
+We may update these Terms from time to time. Changes take effect when posted on
+this page, and your continued use of the Site means you accept the updated Terms.
+
+## Governing law
+
+These Terms are governed by the laws of the State of [STATE], United States,
+without regard to its conflict-of-laws principles.
+
+## Contact us
+
+If you have questions about these Terms, contact us at
+community@avocadolinux.org.
+
+Last updated: 2026-07

--- a/src/docs-overview/policies/terms.md
+++ b/src/docs-overview/policies/terms.md
@@ -77,11 +77,6 @@ collected and how it is used.
 We may update these Terms from time to time. Changes take effect when posted on
 this page, and your continued use of the Site means you accept the updated Terms.
 
-## Governing law
-
-These Terms are governed by the laws of the State of [STATE], United States,
-without regard to its conflict-of-laws principles.
-
 ## Contact us
 
 If you have questions about these Terms, contact us at

--- a/src/docs-overview/policies/terms.md
+++ b/src/docs-overview/policies/terms.md
@@ -5,14 +5,6 @@ description: Terms of Use for the Avocado OS documentation site
 slug: terms
 ---
 
-<!--
-  REVIEW BEFORE MERGE:
-  - Governing-law jurisdiction is a placeholder ([STATE]) — confirm with counsel.
-  - Code-sample reuse stance (see "Intellectual property") — confirm the intended
-    license for code samples.
-  - Confirm the legal entity ("Peridio, Inc.") and contact address.
--->
-
 ## Acceptance of these terms
 
 These Terms of Use ("Terms") govern your access to and use of the Avocado OS
@@ -35,11 +27,12 @@ and is protected by intellectual-property laws. "Peridio" and "Avocado OS", and
 associated logos, are trademarks of Peridio; nothing here grants you a right to
 use them.
 
-You may view and print pages of the Site for your own reference. Unless a page or
-file states otherwise, **code samples in the documentation may be used in your
-own projects.** You may not otherwise copy, republish, or redistribute the
-Site's content, or remove any copyright or proprietary notices, without our
-permission.
+You may view and print pages of the Site for your own personal, internal
+reference. Any other use — including copying, republishing, redistributing, or
+creating derivative works from the Site's content — requires our prior written
+permission, except where a page, file, or repository license expressly permits
+it, or as permitted by applicable law. Do not remove any copyright or
+proprietary notices.
 
 ## Acceptable use
 

--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -225,10 +225,7 @@ const config = {
           {
             title: 'Legal',
             items: [
-              {
-                label: 'Terms & Conditions',
-                href: 'https://console.peridio.com/policy/tos',
-              },
+              { label: 'Terms of Use', to: '/terms' },
               { label: 'Privacy Statement', to: '/privacy' },
               { label: 'Disclaimer', to: '/disclaimer' },
               { label: 'Code of Conduct', to: '/coc' },

--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -207,7 +207,36 @@ const config = {
           },
         ],
       },
-      footer: undefined,
+      footer: {
+        style: 'dark',
+        links: [
+          {
+            title: 'Documentation',
+            items: [
+              { label: 'Product Documentation', to: '/' },
+              { label: 'Hardware', to: '/hardware/support-matrix' },
+              {
+                label: 'Developer Reference',
+                to: '/developer-reference/getting-started',
+              },
+              { label: 'Field Notes', to: '/field-notes' },
+            ],
+          },
+          {
+            title: 'Legal',
+            items: [
+              {
+                label: 'Terms & Conditions',
+                href: 'https://console.peridio.com/policy/tos',
+              },
+              { label: 'Privacy Statement', to: '/privacy' },
+              { label: 'Disclaimer', to: '/disclaimer' },
+              { label: 'Code of Conduct', to: '/coc' },
+            ],
+          },
+        ],
+        copyright: `Copyright © ${new Date().getFullYear()} Peridio, Inc.`,
+      },
       prism: {
         theme: themes.oneLight,
         darkTheme: themes.oneDark,

--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -225,10 +225,10 @@ const config = {
           {
             title: 'Legal',
             items: [
-              { label: 'Terms of Use', to: '/terms' },
-              { label: 'Privacy Statement', to: '/privacy' },
-              { label: 'Disclaimer', to: '/disclaimer' },
-              { label: 'Code of Conduct', to: '/coc' },
+              { label: 'Terms of Use', to: '/policies/terms' },
+              { label: 'Privacy Statement', to: '/policies/privacy' },
+              { label: 'Disclaimer', to: '/policies/disclaimer' },
+              { label: 'Code of Conduct', to: '/policies/coc' },
             ],
           },
         ],

--- a/src/sidebars-overview.js
+++ b/src/sidebars-overview.js
@@ -48,12 +48,7 @@ const sidebars = {
       label: 'Policies',
       collapsible: false,
       collapsed: false,
-      items: [
-        'policies/coc',
-        'policies/terms',
-        'policies/privacy',
-        'policies/disclaimer',
-      ],
+      items: ['policies/coc', 'policies/terms', 'policies/privacy', 'policies/disclaimer'],
     },
   ],
 }

--- a/src/sidebars-overview.js
+++ b/src/sidebars-overview.js
@@ -48,7 +48,7 @@ const sidebars = {
       label: 'Policies',
       collapsible: false,
       collapsed: false,
-      items: ['policies/coc', 'policies/privacy'],
+      items: ['policies/coc', 'policies/privacy', 'policies/disclaimer'],
     },
   ],
 }

--- a/src/sidebars-overview.js
+++ b/src/sidebars-overview.js
@@ -48,7 +48,12 @@ const sidebars = {
       label: 'Policies',
       collapsible: false,
       collapsed: false,
-      items: ['policies/coc', 'policies/privacy', 'policies/disclaimer'],
+      items: [
+        'policies/coc',
+        'policies/terms',
+        'policies/privacy',
+        'policies/disclaimer',
+      ],
     },
   ],
 }

--- a/src/src/data/hardware/generated-targets.json
+++ b/src/src/data/hardware/generated-targets.json
@@ -157,6 +157,33 @@
     "gettingStartedUrl": "/developer-reference/getting-started/any-target",
     "hardwareUrl": "/hardware/nxp/imx8mp"
   },
+  "imx8mp-var-dart": {
+    "name": "Imx8mp Var Dart",
+    "target": "imx8mp-var-dart",
+    "category": "physical",
+    "description": "Imx8mp Var Dart is supported by the Avocado package feed. A detailed getting-started guide for this target hasn't been written yet — the steps below are the standard flow.",
+    "provisioning": {
+      "hostOs": [
+        "macOS",
+        "Linux"
+      ],
+      "prerequisites": [],
+      "options": [
+        {
+          "id": "default",
+          "label": "Default",
+          "profile": null,
+          "media": null,
+          "autoMount": false,
+          "command": "avocado provision -r dev",
+          "bootInstructions": "After provisioning completes, power-cycle the device to boot Avocado OS. The root user is passwordless in the dev runtime."
+        }
+      ]
+    },
+    "serial": null,
+    "gettingStartedUrl": "/developer-reference/getting-started/any-target",
+    "hardwareUrl": null
+  },
   "imx91-frdm": {
     "name": "NXP FRDM i.MX 91",
     "target": "imx91-frdm",

--- a/src/src/data/hardware/generated-targets.json
+++ b/src/src/data/hardware/generated-targets.json
@@ -157,33 +157,6 @@
     "gettingStartedUrl": "/developer-reference/getting-started/any-target",
     "hardwareUrl": "/hardware/nxp/imx8mp"
   },
-  "imx8mp-var-dart": {
-    "name": "Imx8mp Var Dart",
-    "target": "imx8mp-var-dart",
-    "category": "physical",
-    "description": "Imx8mp Var Dart is supported by the Avocado package feed. A detailed getting-started guide for this target hasn't been written yet — the steps below are the standard flow.",
-    "provisioning": {
-      "hostOs": [
-        "macOS",
-        "Linux"
-      ],
-      "prerequisites": [],
-      "options": [
-        {
-          "id": "default",
-          "label": "Default",
-          "profile": null,
-          "media": null,
-          "autoMount": false,
-          "command": "avocado provision -r dev",
-          "bootInstructions": "After provisioning completes, power-cycle the device to boot Avocado OS. The root user is passwordless in the dev runtime."
-        }
-      ]
-    },
-    "serial": null,
-    "gettingStartedUrl": "/developer-reference/getting-started/any-target",
-    "hardwareUrl": null
-  },
   "imx91-frdm": {
     "name": "NXP FRDM i.MX 91",
     "target": "imx91-frdm",


### PR DESCRIPTION
Reduces legal risk on docs.peridio.com. Our own legal pages are self-hosted on-site (no links to the deprecated console). The Privacy Statement links out to Google's policies, which is required when disclosing Google Analytics. Peridio, Inc. (a Delaware corporation) is the owner throughout — Avocado OS and the Avocado Linux project are owned and operated by Peridio.

## Changes
- **Footer** (`docusaurus.config.js`): the site had `footer: undefined`, so no legal links or copyright appeared anywhere. Added a footer with a **Legal** column (Terms of Use, Privacy Statement, Disclaimer, Code of Conduct — all linking on-site `/policies/*`) and a Documentation column, plus `© <year> Peridio, Inc.`
- **Terms of Use** (`policies/terms.md`, new): acceptance, scope, IP/ownership (conservative reserve-rights), acceptable use, warranty disclaimer, limitation of liability, third-party links, privacy pointer, changes, governing law (Delaware), contact.
- **Disclaimer** (`policies/disclaimer.md`, new): as-is / no-warranty, destructive-procedure warning (flashing, provisioning, deploying can erase data or brick hardware), limitation of liability, user responsibility.
- **Privacy Statement** (`policies/privacy.md`): the existing statement falsely claimed *"We do not store IP addresses… We do not log usage information"* while the site runs **Google Analytics** (`G-XN33JD9H3F`). Replaced the false claims with an accurate **Analytics and cookies** disclosure (what GA collects, links to Google's policies, opt-out).
- **Ownership consistency**: privacy, terms, disclaimer, and the footer copyright all attribute ownership/liability to **Peridio, Inc.** Policies sidebar reordered: CoC, Terms, Privacy, Disclaimer.

## Open items (not blocking this PR)
- [ ] **Google Analytics consent** — disclosure is fixed, but a consent mechanism (banner / Consent Mode v2 / cookieless) for EU/UK visitors is a separate decision, not in this PR.
- [ ] Counsel review of the Terms / Disclaimer / Privacy wording (recommended).

## Validation
Ran the CI checks locally against these changes: `prettier --check`, `eslint`, and the full Docusaurus build (broken-link check) all pass.

> Not legal advice.