### PR TITLE
Document the Avocado Desktop MCP server and add MCP troubleshooting

### DIFF
--- a/src/docs-guides/mcp/installation.md
+++ b/src/docs-guides/mcp/installation.md
@@ -12,7 +12,7 @@ It's [open source](https://github.com/avocado-linux/avocado-mcp), runs locally o
 
 ## Prerequisites
 
-- **Node.js ≥ 18** — the server runs via `npx`. On first run, `npx` downloads the package, installs its dependencies, and builds it (~30s); subsequent runs start instantly from cache.
+- **Node.js ≥ 18** — the server runs via `npx`. On first run, `npx` downloads the package, installs its dependencies, and builds it (~30s); subsequent runs start instantly from cache. (Reaching the optional Avocado Desktop server from Claude Desktop bridges through [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), which needs Node **20.18.1+** — see [The Avocado Desktop MCP server](#the-avocado-desktop-mcp-server).)
 - An **MCP-capable client** (Claude Code, Claude Desktop, OpenAI Codex, Cursor, etc.).
 - For building, provisioning, and deploying to real hardware, you'll also want the **Avocado CLI and Docker** installed — see [Getting Started](/developer-reference/getting-started). The MCP drives the CLI on your behalf.
 
@@ -113,10 +113,66 @@ Most clients (Windsurf, Zed, Cline, and others) accept the same `mcpServers` sha
 }
 ```
 
+## The Avocado Desktop MCP server
+
+If you use the [Avocado Desktop](/avocado-desktop/overview) app, it exposes a second MCP server of its own while the app is running: an HTTP server at `http://127.0.0.1:11551/mcp` with tools for driving the app itself (listing and focusing projects, running build and provision actions, VM status and control, USB and serial devices, and UI navigation). The app's built-in agent is connected to both servers automatically; the configs below are for reaching them from an external client instead.
+
+Because this server lives inside the app, it is only reachable while Avocado Desktop is running.
+
+### Claude Code
+
+```bash
+claude mcp add --transport http avocado-desktop http://127.0.0.1:11551/mcp
+```
+
+### Claude Desktop
+
+`claude_desktop_config.json` only accepts command-based (stdio) servers, so bridge the HTTP endpoint with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote). This config connects Claude Desktop to both servers:
+
+```json
+{
+  "mcpServers": {
+    "avocado-os": {
+      "command": "npx",
+      "args": ["-y", "github:avocado-linux/avocado-mcp"]
+    },
+    "avocado-desktop": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://127.0.0.1:11551/mcp"]
+    }
+  }
+}
+```
+
+Quit and reopen Claude Desktop after saving. Note that `mcp-remote` requires Node.js 20.18.1 or newer (a floor set by its dependencies), higher than the Node 18 minimum for the `avocado-os` server alone.
+
+### Clients with native HTTP support
+
+For the `avocado-desktop` HTTP endpoint only, Cursor and several other clients accept a `url` entry directly, with no bridge needed. The `avocado-os` server is stdio, so it keeps the command-based config shown earlier in every client:
+
+```json
+{
+  "mcpServers": {
+    "avocado-desktop": {
+      "url": "http://127.0.0.1:11551/mcp"
+    }
+  }
+}
+```
+
 ## Verify it works
 
-In any connected client, ask:
+To verify the `avocado-os` server, ask in any connected client:
 
 > Start a new Avocado OS project for a Raspberry Pi 5
 
-The assistant should invoke the `start-avocado-project` prompt (or call `list-targets` → `init-project` directly). If it does, you're set — head to [Usage](/developer-reference/mcp/usage) for more ways to put it to work.
+The assistant should invoke the `/start-avocado-project` prompt (or call `list-targets` → `init-project` directly). If it does, you're set — head to [Usage](/developer-reference/mcp/usage) for more ways to put it to work.
+
+To verify the `avocado-desktop` server, make sure the app is running and ask the assistant to report the VM status or list your Avocado projects; it should answer via the desktop server's tools rather than the shell.
+
+## Troubleshooting
+
+- **Restart the client fully after config changes.** An already-open session will not pick up an edited MCP config, and the resulting failure looks identical to a broken server. Quit and reopen the app (or start a new CLI session) after every config edit.
+- **`avocado-os` fails to connect even though npm reports no error.** A strict `~/.npmrc` can block the one-time build the `github:` install runs on first launch — `min-release-age` refuses the git install, and `ignore-scripts` skips the build step. If you set either, comment it out, run `npx -y github:avocado-linux/avocado-mcp` once to prime the cache, then restore your setting; later launches reuse the cached build.
+
+- **The `avocado-desktop` server does not connect.** Its MCP server is only available while the Avocado Desktop app is open. Start the app, then retry from the client.


### PR DESCRIPTION
Customer feedback on the desktop app asked how to use both Avocado MCP servers from Claude Desktop instead of the in-app agent, and hit two setup failures along the way that the docs did not cover.

Additions to the MCP installation page:

- **New section: the Avocado Desktop MCP server.** The app exposes its own HTTP MCP server at `http://127.0.0.1:11551/mcp` while running. Documents Claude Code (`claude mcp add --transport http ...`), Claude Desktop via an `mcp-remote` stdio bridge (its config file only accepts command-based servers), and native-`url` clients like Cursor. Includes a combined `claude_desktop_config.json` example connecting Claude Desktop to both servers.
- **New Troubleshooting section** covering the two failure modes from the feedback: an already-open client session not picking up MCP config edits (looks identical to a broken server), and npm's `min-release-age` setting silently breaking `npx github:` installs (the server's build step aborts, so it "fails to connect" with no install error), with the cache-priming workaround.

Verified against the running app: a raw MCP `initialize` against `127.0.0.1:11551/mcp` and the same handshake through `npx -y mcp-remote` both return the server's capabilities. The `npx -y github:avocado-linux/avocado-mcp` command was verified separately (handshake OK, server v5.1.0).
