### PR TITLE
Remove redundant footer link columns

### DIFF
--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -209,29 +209,6 @@ const config = {
       },
       footer: {
         style: 'dark',
-        links: [
-          {
-            title: 'Documentation',
-            items: [
-              { label: 'Product Documentation', to: '/' },
-              { label: 'Hardware', to: '/hardware/support-matrix' },
-              {
-                label: 'Developer Reference',
-                to: '/developer-reference/getting-started',
-              },
-              { label: 'Field Notes', to: '/field-notes' },
-            ],
-          },
-          {
-            title: 'Legal',
-            items: [
-              { label: 'Terms of Use', to: '/policies/terms' },
-              { label: 'Privacy Statement', to: '/policies/privacy' },
-              { label: 'Disclaimer', to: '/policies/disclaimer' },
-              { label: 'Code of Conduct', to: '/policies/coc' },
-            ],
-          },
-        ],
         copyright: `Copyright © ${new Date().getFullYear()} Peridio, Inc.`,
       },
       prism: {


### PR DESCRIPTION
## What

Remove the two link columns (**Documentation** and **Legal**) from the site footer, keeping only the copyright line.

## Why

Both footer columns duplicated navigation that already lives elsewhere:

- **Documentation** repeated the top navbar exactly (Product Documentation, Hardware, Developer Reference, Field Notes).
- **Legal** duplicated the **Policies** category already present in the root sidebar (Code of Conduct, Terms, Privacy, Disclaimer).

Because the footer renders on every page, on short pages (e.g. the overview/home page) it sat directly beneath the left sidebar, and its "Documentation" column lined up under the nav — so it read like broken side-nav entries.

## Result

- Footer now shows just the centered copyright on every page.
- Legal pages remain reachable via the root sidebar's **Policies** category; documentation sections remain in the top navbar.
- No links removed from the site — only the duplicate footer surface.

Verified with a production build (`npm run build`): footer link columns gone, no broken links.
