### PR TITLE
docs: expand privacy statement for Docs + Desktop analytics disclosure

### DIFF
--- a/src/docs-overview/policies/privacy.md
+++ b/src/docs-overview/policies/privacy.md
@@ -15,8 +15,9 @@ collect, how we use it, and the choices you have.
 
 We want to be clear up front: **we use the information described here only for
 our own internal purposes — to understand how our products are used and to find
-and fix problems so we can improve them. We do not sell, rent, or share this
-information with anyone, and we do not use it for advertising.**
+and fix problems so we can improve them. We do not sell or rent this
+information, and we do not share it with third parties for their own purposes or
+use it for advertising.**
 
 ## Scope
 
@@ -38,8 +39,8 @@ understand how the documentation site is used (see
 [Analytics and cookies](#analytics-and-cookies) below), which collects certain
 information automatically.
 
-Avocado Desktop, unlike the documentation site, requires an Avocado account to
-use.
+Signing in to an Avocado account is optional in Avocado Desktop — you can use
+the application without one.
 
 ### Avocado Desktop
 
@@ -63,10 +64,12 @@ detect and fix defects. This includes:
   analytics provider derives from your IP address. We do not collect precise
   or GPS location.
 
-Because Avocado Desktop requires an Avocado account, events are associated with
-your account **email** so that we can understand usage on a per-user basis and
-provide support. This identifier is shared only with our analytics provider,
-which processes it on our behalf as described in
+If you sign in to your Avocado account, your events — including any captured on
+that device before you signed in — are associated with your account **email** so
+that we can understand usage on a per-user basis and provide support. If you do
+not sign in, events carry a randomly generated identifier stored on your device
+that is not tied to your identity. Either way, this information is shared only
+with our analytics provider, which processes it on our behalf as described in
 [Analytics providers, processing, and sharing](#analytics-providers-processing-and-sharing);
 it is not disclosed to any other third party.
 
@@ -130,10 +133,11 @@ or de-identified in the ordinary course.
 Product analytics in Avocado Desktop is **on by default**, but you are always in
 control and can turn it off at any time in **Settings → Privacy**.
 
-Turning the toggle off disables analytics collection for your account: the
+Turning the toggle off disables analytics collection on that installation: the
 application stops sending events and our analytics provider no longer receives
-or collects any analytics information from it. This takes effect going forward
-and persists across sessions and launches.
+or collects any analytics information from it. The setting is stored on that
+device, so if you use Avocado Desktop on more than one machine you can set it on
+each. This takes effect going forward and persists across sessions and launches.
 
 For the documentation site, you can opt out of Google Analytics across sites
 using Google's [opt-out browser add-on](https://tools.google.com/dlpage/gaoptout),
@@ -144,9 +148,9 @@ and you can manage or block cookies through your browser settings.
 Depending on where you live, you may have the right to access, correct, or
 delete the personal information we hold about you, or to object to or restrict
 certain processing. To exercise any of these rights, contact us at
-support@peridio.com and we will respond as required by applicable law. Because
-Avocado Desktop requires an account, the simplest way to stop further
-collection is to turn analytics off (see [Your choices and opt-out](#your-choices-and-opt-out) above).
+support@peridio.com and we will respond as required by applicable law. The
+simplest way to stop further collection is to turn analytics off in Avocado
+Desktop (see [Your choices and opt-out](#your-choices-and-opt-out) above).
 
 We do not sell your personal information, and we do not share it.
 

--- a/src/docs-overview/policies/privacy.md
+++ b/src/docs-overview/policies/privacy.md
@@ -55,16 +55,18 @@ detect and fix defects. This includes:
 - **Environment and version information** — the versions of the application,
   the Avocado CLI, and the virtual machine you are running, and coarse counts
   such as how many projects you have.
-- **Hardware target and distribution** — the hardware target and distro you
-  build for, and the provisioning method you choose (for example, tegraflash,
-  SD, or USB).
+- **Hardware target and distribution** — the hardware target and Linux
+  distribution you build for, and the provisioning method you choose (for
+  example, tegraflash, SD, or USB).
 - **Crash and error reports** — uncaught errors and failure messages, so we can
   find and fix bugs.
 
 Because Avocado Connect and Avocado Desktop require an Avocado account, events
 are associated with your account **email** so that we can understand usage on a
-per-user basis and provide support. This identifier is held only by us and our
-analytics provider and is never disclosed externally.
+per-user basis and provide support. This identifier is shared only with our
+analytics provider, which processes it on our behalf as described in
+[Analytics providers, processing, and sharing](#analytics-providers-processing-and-sharing);
+it is not disclosed to any other third party.
 
 ## What we do NOT collect
 

--- a/src/docs-overview/policies/privacy.md
+++ b/src/docs-overview/policies/privacy.md
@@ -1,14 +1,14 @@
 ---
 title: Privacy Statement
 sidebar_position: 3
-description: Privacy Statement for the Avocado OS documentation site, Avocado Connect, and Avocado Desktop
+description: Privacy Statement for the Avocado OS documentation site and Avocado Desktop
 slug: privacy
 ---
 
 ## Our Commitment to Privacy
 
 Peridio, Inc. ("Peridio", "we", "us", "our") operates the Avocado OS
-documentation site and the Avocado software applications, and is committed to
+documentation site and the Avocado Desktop application, and is committed to
 protecting your privacy. Avocado OS and the Avocado Linux project are owned and
 operated by Peridio. This Privacy Statement explains what information we
 collect, how we use it, and the choices you have.
@@ -23,11 +23,10 @@ information with anyone, and we do not use it for advertising.**
 This Privacy Statement applies to:
 
 - The **Avocado OS documentation site** (this website).
-- **Avocado Connect**, our web application.
 - **Avocado Desktop**, our desktop application.
 
-Avocado Connect and Avocado Desktop link to this Statement from within the
-applications so you always have access to the current version.
+Avocado Desktop links to this Statement from within the application so you
+always have access to the current version.
 
 ## Information we collect
 
@@ -39,20 +38,19 @@ understand how the documentation site is used (see
 [Analytics and cookies](#analytics-and-cookies) below), which collects certain
 information automatically.
 
-Avocado Connect and Avocado Desktop, unlike the documentation site, require an
-Avocado account to use.
+Avocado Desktop, unlike the documentation site, requires an Avocado account to
+use.
 
-### Avocado Connect and Avocado Desktop
+### Avocado Desktop
 
-When product analytics is enabled, our applications send **product-usage** and
+When product analytics is enabled, Avocado Desktop sends **product-usage** and
 **crash/error** information so we can understand how the software is used and
 detect and fix defects. This includes:
 
 - **Usage events** — which features and workflows you use (for example,
   onboarding steps, creating a project, running Install / Build / Provision /
   Deploy, or opening the agent) and their outcomes (such as success or failure
-  and how long an operation took). In Avocado Connect, this also includes the
-  pages you view and the elements you interact with in the web app.
+  and how long an operation took).
 - **Environment and version information** — the versions of the application,
   the Avocado CLI, and the virtual machine you are running, and coarse counts
   such as how many projects you have.
@@ -65,16 +63,16 @@ detect and fix defects. This includes:
   analytics provider derives from your IP address. We do not collect precise
   or GPS location.
 
-Because Avocado Connect and Avocado Desktop require an Avocado account, events
-are associated with your account **email** so that we can understand usage on a
-per-user basis and provide support. This identifier is shared only with our
-analytics provider, which processes it on our behalf as described in
+Because Avocado Desktop requires an Avocado account, events are associated with
+your account **email** so that we can understand usage on a per-user basis and
+provide support. This identifier is shared only with our analytics provider,
+which processes it on our behalf as described in
 [Analytics providers, processing, and sharing](#analytics-providers-processing-and-sharing);
 it is not disclosed to any other third party.
 
 ## What we do NOT collect
 
-Our applications are designed to leave your content on your machine. We do
+Avocado Desktop is designed to leave your content on your machine. We do
 **not** collect:
 
 - **The contents of your files, projects, or source code.**
@@ -84,8 +82,8 @@ Our applications are designed to leave your content on your machine. We do
 - **Device serial numbers** or the list of USB devices attached to your
   machine.
 
-In Avocado Desktop, crash and error reports are additionally scrubbed on your
-machine before they are sent — secrets, and home-directory paths are removed from the error text.
+Crash and error reports are also scrubbed on your machine before they are
+sent — secrets and home-directory paths are removed from the error text.
 
 ## How we use this information
 
@@ -105,8 +103,7 @@ similarly significant effects about you, and we do not use it for advertising.
 We keep our analytics footprint deliberately small and rely on a limited set of
 service providers who process data **on our behalf** and under our instructions:
 
-- Our **applications** (Avocado Connect and Avocado Desktop) use a single
-  product-analytics provider,
+- **Avocado Desktop** uses a single product-analytics provider,
   [PostHog](https://posthog.com/privacy), to collect and process the usage and
   crash information described above.
 - Our **documentation site** uses **Google Analytics** (see
@@ -123,26 +120,20 @@ de-identified information that cannot reasonably be used to identify you.
 
 ## Data location and retention
 
-Analytics information for our applications is processed and stored on
+Analytics information from Avocado Desktop is processed and stored on
 **US-based** infrastructure. We retain this information only for as long as it
 is needed for the internal purposes described above, after which it is deleted
 or de-identified in the ordinary course.
 
 ## Your choices and opt-out
 
-Product analytics in our applications is **on by default**, but you are always
-in control and can turn it off at any time:
+Product analytics in Avocado Desktop is **on by default**, but you are always in
+control and can turn it off at any time in **Settings → Privacy**.
 
-- **Avocado Connect** — go to **Settings → Account** and turn off the
-  **"Share product analytics"** toggle.
-- **Avocado Desktop** — go to **Settings → Privacy** and turn off the analytics
-  toggle.
-
-Turning the toggle off disables the analytics collection for your account: the application
-stops sending events and our analytics provider no longer receives or collects
-any analytics information from it. This takes effect going forward and persists
-across sessions and launches. We also honor your browser's or operating
-system's **Do Not Track** signal.
+Turning the toggle off disables analytics collection for your account: the
+application stops sending events and our analytics provider no longer receives
+or collects any analytics information from it. This takes effect going forward
+and persists across sessions and launches.
 
 For the documentation site, you can opt out of Google Analytics across sites
 using Google's [opt-out browser add-on](https://tools.google.com/dlpage/gaoptout),
@@ -154,7 +145,7 @@ Depending on where you live, you may have the right to access, correct, or
 delete the personal information we hold about you, or to object to or restrict
 certain processing. To exercise any of these rights, contact us at
 support@peridio.com and we will respond as required by applicable law. Because
-our applications require an account, the simplest way to stop further
+Avocado Desktop requires an account, the simplest way to stop further
 collection is to turn analytics off (see [Your choices and opt-out](#your-choices-and-opt-out) above).
 
 We do not sell your personal information, and we do not share it.
@@ -186,7 +177,7 @@ Peridio.
 If we decide to change our privacy practices, we will post those changes to this
 Privacy Statement and update the "Last updated" date below. We reserve the right
 to modify this Privacy Statement at any time, so please review it frequently.
-Your continued use of the documentation site or our applications after a change
+Your continued use of the documentation site or Avocado Desktop after a change
 takes effect constitutes acceptance of the updated Statement.
 
 ## Contact us

--- a/src/docs-overview/policies/privacy.md
+++ b/src/docs-overview/policies/privacy.md
@@ -51,7 +51,8 @@ detect and fix defects. This includes:
 - **Usage events** — which features and workflows you use (for example,
   onboarding steps, creating a project, running Install / Build / Provision /
   Deploy, or opening the agent) and their outcomes (such as success or failure
-  and how long an operation took).
+  and how long an operation took). In Avocado Connect, this also includes the
+  pages you view and the elements you interact with in the web app.
 - **Environment and version information** — the versions of the application,
   the Avocado CLI, and the virtual machine you are running, and coarse counts
   such as how many projects you have.
@@ -60,6 +61,9 @@ detect and fix defects. This includes:
   example, tegraflash, SD, or USB).
 - **Crash and error reports** — uncaught errors and failure messages, so we can
   find and fix bugs.
+- **Approximate location** — a general region (such as country) that our
+  analytics provider derives from your IP address. We do not collect precise
+  or GPS location.
 
 Because Avocado Connect and Avocado Desktop require an Avocado account, events
 are associated with your account **email** so that we can understand usage on a
@@ -77,10 +81,11 @@ Our applications are designed to leave your content on your machine. We do
 - **The contents of your agent conversations.** We record only _that_ the agent
   was used and how often — never your prompts or the agent's responses.
 - **Your credentials.** API keys, tokens, and passwords are never collected.
-  Error and crash text is automatically scrubbed of secrets, home-directory
-  paths, and IP addresses before it leaves your machine.
-- **Device serial numbers**, or a list of the USB devices attached to your
+- **Device serial numbers** or the list of USB devices attached to your
   machine.
+
+In Avocado Desktop, crash and error reports are additionally scrubbed on your
+machine before they are sent — secrets, and home-directory paths are removed from the error text.
 
 ## How we use this information
 
@@ -133,13 +138,26 @@ in control and can turn it off at any time:
 - **Avocado Desktop** — go to **Settings → Privacy** and turn off the analytics
   toggle.
 
-Opting out stops collection going forward and persists across sessions and
-launches. We also honor your browser's or operating system's **Do Not Track**
-signal.
+Turning the toggle off disables the analytics collection for your account: the application
+stops sending events and our analytics provider no longer receives or collects
+any analytics information from it. This takes effect going forward and persists
+across sessions and launches. We also honor your browser's or operating
+system's **Do Not Track** signal.
 
 For the documentation site, you can opt out of Google Analytics across sites
 using Google's [opt-out browser add-on](https://tools.google.com/dlpage/gaoptout),
 and you can manage or block cookies through your browser settings.
+
+## Your data rights
+
+Depending on where you live, you may have the right to access, correct, or
+delete the personal information we hold about you, or to object to or restrict
+certain processing. To exercise any of these rights, contact us at
+support@peridio.com and we will respond as required by applicable law. Because
+our applications require an account, the simplest way to stop further
+collection is to turn analytics off (see [Your choices and opt-out](#your-choices-and-opt-out) above).
+
+We do not sell your personal information, and we do not share it.
 
 ## Analytics and cookies
 

--- a/src/docs-overview/policies/privacy.md
+++ b/src/docs-overview/policies/privacy.md
@@ -1,28 +1,147 @@
 ---
 title: Privacy Statement
 sidebar_position: 3
-description: Privacy Statement for the Avocado OS documentation site
+description: Privacy Statement for the Avocado OS documentation site, Avocado Connect, and Avocado Desktop
 slug: privacy
 ---
 
 ## Our Commitment to Privacy
 
-Peridio, Inc. ("Peridio", "we", "us") operates the Avocado OS documentation site
-and is committed to protecting your privacy. Avocado OS and the Avocado Linux
-project are owned and operated by Peridio. This Privacy Statement explains our
-data practices regarding the information we collect.
+Peridio, Inc. ("Peridio", "we", "us", "our") operates the Avocado OS
+documentation site and the Avocado software applications, and is committed to
+protecting your privacy. Avocado OS and the Avocado Linux project are owned and
+operated by Peridio. This Privacy Statement explains what information we
+collect, how we use it, and the choices you have.
+
+We want to be clear up front: **we use the information described here only for
+our own internal purposes — to understand how our products are used and to find
+and fix problems so we can improve them. We do not sell, rent, or share this
+information with anyone, and we do not use it for advertising.**
+
+## Scope
+
+This Privacy Statement applies to:
+
+- The **Avocado OS documentation site** (this website).
+- **Avocado Connect**, our web application.
+- **Avocado Desktop**, our desktop application.
+
+Avocado Connect and Avocado Desktop link to this Statement from within the
+applications so you always have access to the current version.
 
 ## Information we collect
 
-We do not require you to create an account, and we do not ask you to provide
-personal information in order to read this documentation.
+### Documentation site
 
-We do, however, use analytics to understand how this documentation site is used
-(see below), which collects certain information automatically.
+We do not require you to create an account, and we do not ask you to provide
+personal information in order to read this documentation. We do use analytics to
+understand how the documentation site is used (see
+[Analytics and cookies](#analytics-and-cookies) below), which collects certain
+information automatically.
+
+Avocado Connect and Avocado Desktop, unlike the documentation site, require an
+Avocado account to use.
+
+### Avocado Connect and Avocado Desktop
+
+When product analytics is enabled, our applications send **product-usage** and
+**crash/error** information so we can understand how the software is used and
+detect and fix defects. This includes:
+
+- **Usage events** — which features and workflows you use (for example,
+  onboarding steps, creating a project, running Install / Build / Provision /
+  Deploy, or opening the agent) and their outcomes (such as success or failure
+  and how long an operation took).
+- **Environment and version information** — the versions of the application,
+  the Avocado CLI, and the virtual machine you are running, and coarse counts
+  such as how many projects you have.
+- **Hardware target and distribution** — the hardware target and distro you
+  build for, and the provisioning method you choose (for example, tegraflash,
+  SD, or USB).
+- **Crash and error reports** — uncaught errors and failure messages, so we can
+  find and fix bugs.
+
+Because Avocado Connect and Avocado Desktop require an Avocado account, events
+are associated with your account **email** so that we can understand usage on a
+per-user basis and provide support. This identifier is held only by us and our
+analytics provider and is never disclosed externally.
+
+## What we do NOT collect
+
+Our applications are designed to leave your content on your machine. We do
+**not** collect:
+
+- **The contents of your files, projects, or source code.**
+- **The contents of your agent conversations.** We record only _that_ the agent
+  was used and how often — never your prompts or the agent's responses.
+- **Your credentials.** API keys, tokens, and passwords are never collected.
+  Error and crash text is automatically scrubbed of secrets, home-directory
+  paths, and IP addresses before it leaves your machine.
+- **Device serial numbers**, or a list of the USB devices attached to your
+  machine.
+
+## How we use this information
+
+We use the information described in this Statement **solely for our own internal
+business purposes**, namely to:
+
+- understand how our products and documentation are used;
+- diagnose, reproduce, and fix crashes, errors, and other defects;
+- measure the reliability and performance of features; and
+- prioritize and improve the products over time.
+
+We do not use this information to make automated decisions that produce legal or
+similarly significant effects about you, and we do not use it for advertising.
+
+## Analytics providers, processing, and sharing
+
+We keep our analytics footprint deliberately small and rely on a limited set of
+service providers who process data **on our behalf** and under our instructions:
+
+- Our **applications** (Avocado Connect and Avocado Desktop) use a single
+  product-analytics provider,
+  [PostHog](https://posthog.com/privacy), to collect and process the usage and
+  crash information described above.
+- Our **documentation site** uses **Google Analytics** (see
+  [Analytics and cookies](#analytics-and-cookies) below).
+
+These providers are engaged as processors: they process the information only to
+provide their services to us, under contractual confidentiality and
+data-protection obligations, and they are not permitted to use it for their own
+purposes. We **do not** sell, rent, trade, or otherwise share this information
+with third parties for their own use, and we **do not** disclose it to
+advertisers or data brokers. We may disclose information only where required to
+do so by law, or to protect our legal rights, and we may share aggregated or
+de-identified information that cannot reasonably be used to identify you.
+
+## Data location and retention
+
+Analytics information for our applications is processed and stored on
+**US-based** infrastructure. We retain this information only for as long as it
+is needed for the internal purposes described above, after which it is deleted
+or de-identified in the ordinary course.
+
+## Your choices and opt-out
+
+Product analytics in our applications is **on by default**, but you are always
+in control and can turn it off at any time:
+
+- **Avocado Connect** — go to **Settings → Account** and turn off the
+  **"Share product analytics"** toggle.
+- **Avocado Desktop** — go to **Settings → Privacy** and turn off the analytics
+  toggle.
+
+Opting out stops collection going forward and persists across sessions and
+launches. We also honor your browser's or operating system's **Do Not Track**
+signal.
+
+For the documentation site, you can opt out of Google Analytics across sites
+using Google's [opt-out browser add-on](https://tools.google.com/dlpage/gaoptout),
+and you can manage or block cookies through your browser settings.
 
 ## Analytics and cookies
 
-This documentation site uses **Google Analytics**, a web analytics service
+The documentation site uses **Google Analytics**, a web analytics service
 provided by Google, to help us understand how visitors use the site so we can
 improve it. Google Analytics uses cookies and similar technologies and may
 collect information automatically, including:
@@ -35,11 +154,8 @@ collect information automatically, including:
 This information is processed by Google on our behalf in accordance with
 [Google's Privacy Policy](https://policies.google.com/privacy) and
 [how Google uses data from sites that use its services](https://policies.google.com/technologies/partner-sites).
-You can opt out of Google Analytics across sites using Google's
-[opt-out browser add-on](https://tools.google.com/dlpage/gaoptout), and you can
-manage or block cookies through your browser settings.
 
-## Third-Party Services
+## Third-party services
 
 Our documentation is hosted on GitHub, which may maintain standard server logs
 for security and maintenance purposes. These logs are not accessed or used by
@@ -47,10 +163,15 @@ Peridio.
 
 ## Changes to this privacy statement
 
-If we decide to change our privacy practices, we will post those changes to this Privacy Statement. We reserve the right to modify this Privacy Statement at any time, so please review it frequently.
+If we decide to change our privacy practices, we will post those changes to this
+Privacy Statement and update the "Last updated" date below. We reserve the right
+to modify this Privacy Statement at any time, so please review it frequently.
+Your continued use of the documentation site or our applications after a change
+takes effect constitutes acceptance of the updated Statement.
 
-## Contact Us
+## Contact us
 
-If you have any questions about this Privacy Statement, please contact us at community@avocadolinux.org.
+If you have any questions about this Privacy Statement or your data, please
+contact us at [support@peridio.com](mailto:support@peridio.com).
 
-Last updated: 2026-07
+Last updated: 2026-08


### PR DESCRIPTION
## Summary

Broadens the docs-site Privacy Statement so **Avocado Desktop** can link to it, and adds our first-party product-analytics disclosure.

- **Scope** — covers the docs site and Avocado Desktop; Desktop links to this policy from within the app. Sign-in is optional (docs needs no account either).
- **What we collect (Desktop)** — usage events, app/CLI/VM versions, hardware target + Linux distribution, crash/error reports, and approximate (region-level) location derived from your IP.
- **What we do NOT collect** — no source/file/project contents, no agent conversation content, no credentials. Desktop crash/error *text* is scrubbed of secrets and home-dir paths before sending.
- **Identity** — events tie to your email only if you sign in; otherwise a random on-device identifier.
- **Processing & sharing** — single product-analytics provider (PostHog), US-based, processed on our behalf; not sold/rented, not shared with third parties for their own purposes; internal use only.
- **Opt-out** — Desktop: Settings → Privacy (per-installation). Docs-site Google Analytics opt-out retained.

## Related

- ENG-2393
- Desktop analytics PR: avocado-linux/avocado-desktop#83