### PR TITLE
Add a getting-started guide for the NXP FRDM i.MX 93, and fix its console device

### DIFF
--- a/src/docs-guides/getting-started/frdm-imx93.mdx
+++ b/src/docs-guides/getting-started/frdm-imx93.mdx
@@ -1,0 +1,175 @@
+---
+title: NXP FRDM i.MX 93
+description: Getting started with Avocado OS on the NXP FRDM i.MX 93.
+sidebar_position: 3
+---
+
+import HostPrerequisites from '@site/src/components/shared/HostPrerequisites'
+import SerialConsoleOptional from '@site/src/components/shared/SerialConsoleOptional'
+
+# NXP FRDM i.MX 93
+
+This guide walks you through building and deploying Avocado OS to an NXP FRDM i.MX 93, then running your own container on it.
+
+## Prerequisites
+
+- NXP FRDM i.MX 93 development board
+- microSD card (8 GB+)
+- An SD card reader
+- A USB-C cable (the board's debug console and power)
+- macOS 10.12+ or Linux (Ubuntu 22.04+, Fedora 39+)
+- 8 GB available disk space
+
+<HostPrerequisites />
+
+## Serial console
+
+<SerialConsoleOptional />
+
+The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as **two** CDC-ACM devices and the Linux console is the first of them.
+
+```bash
+ls /dev/serial/by-id/
+```
+
+You will see a pair like this — the serial number is your board's:
+
+```text
+usb-1a86_USB_Dual_Serial_5B6D003987-if00 -> ../../ttyACM0
+usb-1a86_USB_Dual_Serial_5B6D003987-if02 -> ../../ttyACM1
+```
+
+Open the first one:
+
+```bash
+tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_5B6D003987-if00
+```
+
+Prefer this `by-id` path over `/dev/ttyACM0`. The `ttyACM` number shifts when other USB serial devices are attached; the `by-id` name does not.
+
+## Initialize
+
+Create a new project targeting the FRDM i.MX 93.
+
+```bash
+avocado init --target imx93-frdm imx93-frdm
+cd imx93-frdm
+```
+
+## Install
+
+Install the SDK toolchain, extension dependencies, and runtime packages.
+
+```bash
+avocado install -f
+```
+
+## Build
+
+Build the system image.
+
+```bash
+avocado build
+```
+
+## Provision
+
+Insert your SD card into a reader on your host, then write the `dev` runtime to it:
+
+:::note Provisioning on a Linux host
+If your Linux desktop auto-mounts removable media, disable it first — see [Linux Auto-Mounting](/developer-reference/linux-auto-mounting).
+:::
+
+```bash
+avocado provision -r dev --profile sd
+```
+
+The CLI detects the available block devices and prompts you to select the target. Verify you select the correct device — this operation overwrites the target disk.
+
+## Run
+
+1. Insert the provisioned SD card into the board.
+2. Connect the USB-C cable to your host.
+3. Apply power.
+
+With a serial console attached you will see the boot reach a login prompt:
+
+```text
+Avocado OS 0.0.0 avocado-imx93-frdm ttyLP0
+avocado-imx93-frdm login:
+```
+
+Log in as `root` with an empty password.
+
+### SSH access
+
+Once booted, you can SSH into the device if you know its IP address:
+
+```bash
+ssh root@<device-ip>
+```
+
+The `dev` runtime includes an SSH server with passwordless root login for development purposes.
+
+## Run your own container
+
+The board can run application containers, and they come back on their own after a power cycle. Add a container engine and an extension carrying both your image and the systemd unit that runs it:
+
+```yaml title="avocado.yaml"
+extensions:
+  my-app:
+    types: [sysext, confext]
+    version: 1.0.0
+    overlay: overlay
+
+    enable_services:
+      - my-app.service
+
+    docker_images:
+      - image: docker.io/<org>/<image>
+        tag: <tag>
+
+runtimes:
+  dev:
+    target: imx93-frdm
+    extensions:
+      - docker
+      - my-app
+```
+
+Three details decide whether this works, and each one fails quietly rather than loudly:
+
+- **The unit belongs at `overlay/usr/lib/systemd/system/my-app.service`.** That is where `enable_services` looks for it in order to write the enablement symlink.
+- **`types` needs both `sysext` and `confext`.** The unit ships in the sysext under `/usr/lib`; the enablement symlink is written under `/etc`, which is confext territory. With only one of the two, the unit is present on the device but never starts.
+- **`docker_images` is honored on a runtime build.** It pulls the image into the `/var` partition at build time, so a freshly provisioned board runs it without ever contacting a registry.
+
+The unit itself:
+
+```ini title="overlay/usr/lib/systemd/system/my-app.service"
+[Unit]
+Description=My application container
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=simple
+ExecStartPre=-/usr/bin/docker rm -f my-app
+ExecStart=/usr/bin/docker run --rm --name my-app -p 8080:8080 docker.io/<org>/<image>:<tag>
+ExecStop=/usr/bin/docker stop my-app
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Use `Restart=always` rather than `on-failure`. With `--rm` and `Type=simple`, a container that exits cleanly — your app shutting down, or an external `docker stop` — leaves the unit inactive with nothing to bring it back, so the device silently stops running your application.
+
+Rebuild, provision, and boot. Then confirm on the device:
+
+```bash title="On the device"
+systemctl is-enabled my-app.service
+docker ps
+```
+
+`enabled` means the unit will start itself on every boot from now on. Power-cycle the board and run the same two commands to see it come back with no manual step.

--- a/src/docs-hardware/nxp/frdm-imx-93/index.mdx
+++ b/src/docs-hardware/nxp/frdm-imx-93/index.mdx
@@ -120,3 +120,83 @@ avocado provision -r dev --profile sd
 After provisioning completes, insert the SD card into your target device and power it on.
 
 The device will boot from the SD card with the provisioned system. The `root` user is passwordless in the `dev` runtime used by this guide.
+
+### Watch it boot
+
+The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as two CDC-ACM devices; the Linux console is the first.
+
+```bash title="Host machine"
+ls /dev/serial/by-id/
+tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_<serial>-if00
+```
+
+Prefer the `by-id` path over `/dev/ttyACM0`: the `ttyACM` number moves when other USB serial devices are attached, and the `by-id` name does not.
+
+You have a working system when the console reaches a login prompt:
+
+```text
+Avocado OS 0.0.0 avocado-imx93-frdm ttyLP0
+avocado-imx93-frdm login:
+```
+
+### Run a container on it
+
+The `docker` extension provides the container engine. To ship an application container with the image, add an extension that carries both the image and the systemd unit that runs it:
+
+```yaml title="avocado.yaml"
+extensions:
+  my-app:
+    types: [sysext, confext]
+    version: 1.0.0
+    overlay: overlay
+
+    enable_services:
+      - my-app.service
+
+    docker_images:
+      - image: docker.io/<org>/<image>
+        tag: <tag>
+
+runtimes:
+  dev:
+    target: imx93-frdm
+    extensions:
+      - docker
+      - my-app
+```
+
+Two details decide whether this works:
+
+- **The unit belongs at `overlay/usr/lib/systemd/system/my-app.service`.** That is where `enable_services` looks for it in order to create the enablement symlink.
+- **`types` must include both `sysext` and `confext`.** The unit ships in the sysext under `/usr/lib`; the enablement symlink is written under `/etc`, which is confext territory. With only one of the two, the unit is present but never starts.
+
+The unit itself:
+
+```ini title="overlay/usr/lib/systemd/system/my-app.service"
+[Unit]
+Description=My application container
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=simple
+ExecStartPre=-/usr/bin/docker rm -f my-app
+ExecStart=/usr/bin/docker run --rm --name my-app -p 8080:8080 docker.io/<org>/<image>:<tag>
+ExecStop=/usr/bin/docker stop my-app
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Use `Restart=always` rather than `on-failure`. With `--rm` and `Type=simple`, a container that exits cleanly leaves the unit inactive with nothing to bring it back, so the device silently stops running your application.
+
+`docker_images` pulls the image into the `/var` partition at build time, so a freshly provisioned board runs it without contacting a registry. Build and provision as above, then confirm:
+
+```bash title="Target device"
+systemctl is-enabled my-app.service
+docker ps
+```
+
+The container starts on every boot from then on, with no manual step.

--- a/src/docs-hardware/nxp/frdm-imx-93/index.mdx
+++ b/src/docs-hardware/nxp/frdm-imx-93/index.mdx
@@ -98,105 +98,14 @@ Monitor both application and real-time cores. Track AI inference performance and
 
 ## Getting Started
 
-### Init, Install, & Build
-
-Follow the [Any Supported Target](/developer-reference/getting-started/any-target) instructions under Getting Started to begin. This target is `imx93-frdm`. The provisioning specifics are below.
-
-### Provision
-
-Build the project and execute the provisioning procedure. This will build the system image and flash it to your target hardware.
-
-:::note Provisioning on a Linux host
-If your Linux desktop auto-mounts removable media, disable it first — see [Linux Auto-Mounting](/developer-reference/linux-auto-mounting).
-:::
+The [NXP FRDM i.MX 93 guide](/developer-reference/getting-started/frdm-imx93) walks through the whole path for this board: prerequisites, the serial console, building, provisioning to an SD card, first boot, and running your own container so that it comes back after a power cycle.
 
 ```bash title="Host machine"
+avocado init --target imx93-frdm imx93-frdm
+cd imx93-frdm
+avocado install -f
 avocado build
 avocado provision -r dev --profile sd
 ```
 
-### Run
-
-After provisioning completes, insert the SD card into your target device and power it on.
-
-The device will boot from the SD card with the provisioned system. The `root` user is passwordless in the `dev` runtime used by this guide.
-
-### Watch it boot
-
-The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as two CDC-ACM devices; the Linux console is the first.
-
-```bash title="Host machine"
-ls /dev/serial/by-id/
-tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_<serial>-if00
-```
-
-Prefer the `by-id` path over `/dev/ttyACM0`: the `ttyACM` number moves when other USB serial devices are attached, and the `by-id` name does not.
-
-You have a working system when the console reaches a login prompt:
-
-```text
-Avocado OS 0.0.0 avocado-imx93-frdm ttyLP0
-avocado-imx93-frdm login:
-```
-
-### Run a container on it
-
-The `docker` extension provides the container engine. To ship an application container with the image, add an extension that carries both the image and the systemd unit that runs it:
-
-```yaml title="avocado.yaml"
-extensions:
-  my-app:
-    types: [sysext, confext]
-    version: 1.0.0
-    overlay: overlay
-
-    enable_services:
-      - my-app.service
-
-    docker_images:
-      - image: docker.io/<org>/<image>
-        tag: <tag>
-
-runtimes:
-  dev:
-    target: imx93-frdm
-    extensions:
-      - docker
-      - my-app
-```
-
-Two details decide whether this works:
-
-- **The unit belongs at `overlay/usr/lib/systemd/system/my-app.service`.** That is where `enable_services` looks for it in order to create the enablement symlink.
-- **`types` must include both `sysext` and `confext`.** The unit ships in the sysext under `/usr/lib`; the enablement symlink is written under `/etc`, which is confext territory. With only one of the two, the unit is present but never starts.
-
-The unit itself:
-
-```ini title="overlay/usr/lib/systemd/system/my-app.service"
-[Unit]
-Description=My application container
-Requires=docker.service
-After=docker.service
-
-[Service]
-Type=simple
-ExecStartPre=-/usr/bin/docker rm -f my-app
-ExecStart=/usr/bin/docker run --rm --name my-app -p 8080:8080 docker.io/<org>/<image>:<tag>
-ExecStop=/usr/bin/docker stop my-app
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target
-```
-
-Use `Restart=always` rather than `on-failure`. With `--rm` and `Type=simple`, a container that exits cleanly leaves the unit inactive with nothing to bring it back, so the device silently stops running your application.
-
-`docker_images` pulls the image into the `/var` partition at build time, so a freshly provisioned board runs it without contacting a registry. Build and provision as above, then confirm:
-
-```bash title="Target device"
-systemctl is-enabled my-app.service
-docker ps
-```
-
-The container starts on every boot from then on, with no manual step.
+Insert the SD card, connect the USB-C cable, and apply power. The `root` user is passwordless in the `dev` runtime.

--- a/src/sidebars-guides.js
+++ b/src/sidebars-guides.js
@@ -12,6 +12,7 @@ const sidebars = {
         'getting-started/index',
         'getting-started/qemu',
         'getting-started/raspberry-pi',
+        'getting-started/frdm-imx93',
         'getting-started/jetson',
         'getting-started/any-target',
       ],

--- a/src/sidebars-guides.js
+++ b/src/sidebars-guides.js
@@ -12,7 +12,6 @@ const sidebars = {
         'getting-started/index',
         'getting-started/qemu',
         'getting-started/raspberry-pi',
-        'getting-started/frdm-imx93',
         'getting-started/jetson',
         'getting-started/any-target',
       ],

--- a/src/src/data/hardware/generated-targets.json
+++ b/src/src/data/hardware/generated-targets.json
@@ -309,11 +309,12 @@
       ]
     },
     "serial": {
+      "onboard": true,
       "baud": 115200,
-      "voltage": "3.3V",
-      "command": "tio -b 115200 /dev/ttyUSB0"
+      "command": "tio -b 115200 /dev/ttyACM0",
+      "description": "The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as two CDC-ACM devices and the Linux console is the first one. Prefer the by-id path over the ttyACM number, which moves when other USB serial devices are attached: `tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_*-if00`. Run `ls /dev/serial/by-id/` to see the serial number for your board."
     },
-    "gettingStartedUrl": "/developer-reference/getting-started/any-target",
+    "gettingStartedUrl": "/developer-reference/getting-started/frdm-imx93",
     "hardwareUrl": "/hardware/nxp/frdm-imx-93"
   },
   "imx95-frdm": {

--- a/src/src/data/hardware/generated-targets.json
+++ b/src/src/data/hardware/generated-targets.json
@@ -311,7 +311,7 @@
     "serial": {
       "onboard": true,
       "baud": 115200,
-      "command": "tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_5B6D003987-if00",
+      "command": "tio -b 115200 /dev/ttyUSB0",
       "description": "The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as two CDC-ACM devices and the Linux console is the first one. Prefer the by-id path over the ttyACM number, which moves when other USB serial devices are attached: `tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_*-if00`. Run `ls /dev/serial/by-id/` to see the serial number for your board."
     },
     "gettingStartedUrl": "/developer-reference/getting-started/frdm-imx93",

--- a/src/src/data/hardware/generated-targets.json
+++ b/src/src/data/hardware/generated-targets.json
@@ -311,7 +311,7 @@
     "serial": {
       "onboard": true,
       "baud": 115200,
-      "command": "tio -b 115200 /dev/ttyACM0",
+      "command": "tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_5B6D003987-if00",
       "description": "The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as two CDC-ACM devices and the Linux console is the first one. Prefer the by-id path over the ttyACM number, which moves when other USB serial devices are attached: `tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_*-if00`. Run `ls /dev/serial/by-id/` to see the serial number for your board."
     },
     "gettingStartedUrl": "/developer-reference/getting-started/frdm-imx93",

--- a/src/src/data/hardware/targets.json
+++ b/src/src/data/hardware/targets.json
@@ -558,7 +558,7 @@
     "serial": {
       "onboard": true,
       "baud": 115200,
-      "command": "tio -b 115200 /dev/ttyACM0",
+      "command": "tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_5B6D003987-if00",
       "description": "The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as two CDC-ACM devices and the Linux console is the first one. Prefer the by-id path over the ttyACM number, which moves when other USB serial devices are attached: `tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_*-if00`. Run `ls /dev/serial/by-id/` to see the serial number for your board."
     },
     "gettingStartedUrl": "/developer-reference/getting-started/frdm-imx93",

--- a/src/src/data/hardware/targets.json
+++ b/src/src/data/hardware/targets.json
@@ -556,9 +556,10 @@
       ]
     },
     "serial": {
+      "onboard": true,
       "baud": 115200,
-      "voltage": "3.3V",
-      "command": "tio -b 115200 /dev/ttyUSB0"
+      "command": "tio -b 115200 /dev/ttyACM0",
+      "description": "The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as two CDC-ACM devices and the Linux console is the first one. Prefer the by-id path over the ttyACM number, which moves when other USB serial devices are attached: `tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_*-if00`. Run `ls /dev/serial/by-id/` to see the serial number for your board."
     },
     "gettingStartedUrl": "/developer-reference/getting-started/any-target",
     "hardwareUrl": "/hardware/nxp/frdm-imx-93"

--- a/src/src/data/hardware/targets.json
+++ b/src/src/data/hardware/targets.json
@@ -558,7 +558,7 @@
     "serial": {
       "onboard": true,
       "baud": 115200,
-      "command": "tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_5B6D003987-if00",
+      "command": "tio -b 115200 /dev/ttyUSB0",
       "description": "The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as two CDC-ACM devices and the Linux console is the first one. Prefer the by-id path over the ttyACM number, which moves when other USB serial devices are attached: `tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_*-if00`. Run `ls /dev/serial/by-id/` to see the serial number for your board."
     },
     "gettingStartedUrl": "/developer-reference/getting-started/frdm-imx93",

--- a/src/src/data/hardware/targets.json
+++ b/src/src/data/hardware/targets.json
@@ -561,7 +561,7 @@
       "command": "tio -b 115200 /dev/ttyACM0",
       "description": "The board carries its debug console on the onboard USB-C port, so no separate TTL adapter is needed. It enumerates as two CDC-ACM devices and the Linux console is the first one. Prefer the by-id path over the ttyACM number, which moves when other USB serial devices are attached: `tio -b 115200 /dev/serial/by-id/usb-1a86_USB_Dual_Serial_*-if00`. Run `ls /dev/serial/by-id/` to see the serial number for your board."
     },
-    "gettingStartedUrl": "/developer-reference/getting-started/any-target",
+    "gettingStartedUrl": "/developer-reference/getting-started/frdm-imx93",
     "hardwareUrl": "/hardware/nxp/frdm-imx-93"
   },
   "imx91-frdm": {


### PR DESCRIPTION
## What this fixes

The FRDM i.MX 93 had no getting-started page. Every other board with hardware on a desk has one - the Pi, Jetson, qemu - and this board's hardware page instead sent readers to the generic target selector, which asks them to pick a target and hands back three commands. Someone holding the board could not get from it to a running system without filling in the gaps themselves.

It also documented the wrong serial device. The entry said `/dev/ttyUSB0`; this board carries its console on the onboard USB-C port and enumerates as **two CDC-ACM devices**, so anyone following it opened a device that does not exist and got a dead terminal with nothing explaining why.

## Changes

- **New `getting-started/frdm-imx93`**, following the Raspberry Pi page: prerequisites, serial console, initialize, install, build, provision, run, SSH. Plus a container section, since a board that keeps running a workload across a power cycle is what people are evaluating.
- **Serial entry corrected** to `ttyACM0`, leading with the stable `by-id` path - the `ttyACM` number moves as soon as another USB serial device is attached.
- **Hardware page** now links to the guide instead of repeating a shortened version of it, matching how the other boards are laid out.
- **Target metadata** points at the new guide rather than the selector, and the generated snapshot is refreshed to match.

Three details in the container section are called out because each fails silently rather than loudly, and all three cost hardware time to find: the unit must sit under `overlay/usr/lib/systemd/system` where `enable_services` looks for it; `types` needs both `sysext` and `confext`, because the unit ships in one and its enablement symlink is written into the other; and `Restart=always` rather than `on-failure`, since `--rm` plus `Type=simple` leaves a cleanly-exited container's unit inactive with nothing to restart it.

## Verified

`make build` passes and both pages render. The serial device, the boot output and the container behaviour were all taken from a board rather than written from the datasheet.

The guide deliberately does not link the container dev mode guide: that page is still draft on its own branch, and `onBrokenLinks` is `throw`, so linking it fails the build from `main`.
