### PR TITLE
Point download entry points at artifacts instead of descriptions

### DIFF
--- a/src/docs-guides/avocado-cli/installation.md
+++ b/src/docs-guides/avocado-cli/installation.md
@@ -19,7 +19,9 @@ Avocado CLI ships prebuilt binaries for the following OS / architecture combinat
 
 The Linux `*-musl` builds are statically linked, so they do not depend on the host glibc version, but they still require a compatible Linux kernel and matching architecture. The `*-gnu` build is dynamically linked against glibc and is suitable for mainstream Linux distributions with glibc 2.31 or newer (Debian 11+, Ubuntu 20.04+, Fedora 33+, RHEL 9+).
 
-The install script picks the appropriate binary automatically. For manual installs, download the matching artifact from the [releases page](https://github.com/avocado-linux/avocado-cli/releases).
+The install script picks the appropriate binary automatically. For manual installs, download the matching artifact from the [releases page](https://github.com/avocado-linux/avocado-cli/releases), or use [Downloads](https://www.peridio.com/downloads#cli-artifacts), which lists every shipping build with its size and SHA-256.
+
+Prefer a native app? [Avocado Desktop](https://www.peridio.com/downloads#desktop) bundles the CLI, the build VM, and the cross-compilation toolchain in one install.
 
 ## Install
 

--- a/src/docs-guides/avocado-cli/overview.md
+++ b/src/docs-guides/avocado-cli/overview.md
@@ -8,6 +8,10 @@ description: 'Avocado CLI tool for initializing, configuring, building, and prov
 
 The Avocado CLI is a powerful tool that allows you to initialize, configure, build, and provision Avocado OS projects.
 
+:::tip Get the CLI
+This page describes what the CLI does. To install it, see [Installation](/developer-reference/avocado-cli/installation), or browse every build, size, and checksum on [Downloads](https://www.peridio.com/downloads#cli-artifacts).
+:::
+
 The CLI provides comprehensive functionality for managing the entire Avocado OS development lifecycle. Core capabilities include project initialization with target architecture support, building and managing SDK environments for cross-compilation, creating and packaging system extensions (sysext) and configuration extensions (confext), managing rootfs and initramfs sysroots, building runtime images, and deploying to target devices.
 
 Advanced features include Avocado Connect platform integration for fleet management (device provisioning, OTA updates, signing key delegation, and trust posture management), hardware-in-the-loop (HITL) testing server support, dependency management with DNF integration, repository metadata fetching and refreshing, container-based development workflows, and flexible provisioning profiles.

--- a/src/docs-guides/getting-started/index.mdx
+++ b/src/docs-guides/getting-started/index.mdx
@@ -43,7 +43,7 @@ Welcome to Avocado OS. Choose a target platform below to get up and running.
 <CalloutButton
   label={<>Prefer a native app?<br />Avocado Desktop bundles the toolchain and an AI agent that drives it for you.</>}
   cta="Get Avocado Desktop"
-  href="https://www.peridio.com/downloads#desktop"
+  href="/avocado-desktop/overview"
 />
 
 ## Choose Your Platform

--- a/src/docs-guides/getting-started/index.mdx
+++ b/src/docs-guides/getting-started/index.mdx
@@ -42,8 +42,8 @@ Welcome to Avocado OS. Choose a target platform below to get up and running.
 
 <CalloutButton
   label={<>Prefer a native app?<br />Avocado Desktop bundles the toolchain and an AI agent that drives it for you.</>}
-  cta="Avocado Desktop"
-  href="/avocado-desktop/overview"
+  cta="Get Avocado Desktop"
+  href="https://www.peridio.com/downloads#desktop"
 />
 
 ## Choose Your Platform

--- a/src/docs-guides/mcp/installation.md
+++ b/src/docs-guides/mcp/installation.md
@@ -14,7 +14,7 @@ It's [open source](https://github.com/avocado-linux/avocado-mcp), runs locally o
 
 - **Node.js ≥ 20** — the server runs via `npx`. On first run, `npx` downloads the package, installs its dependencies, and builds it (~30s); subsequent runs start instantly from cache. (Reaching the optional Avocado Desktop server from Claude Desktop bridges through [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), which needs Node **20.18.1+** — see [The Avocado Desktop MCP server](#the-avocado-desktop-mcp-server).)
 - An **MCP-capable client** (Claude Code, Claude Desktop, OpenAI Codex, Cursor, etc.).
-- For building, provisioning, and deploying to real hardware, you'll also want the **Avocado CLI and Docker** installed — see [Getting Started](/developer-reference/getting-started). The MCP drives the CLI on your behalf.
+- For building, provisioning, and deploying to real hardware, you'll also want the **Avocado CLI and Docker** installed — see [CLI installation](/developer-reference/avocado-cli/installation), or start from [Getting Started](/developer-reference/getting-started). The MCP drives the CLI on your behalf.
 
 ## The server command
 

--- a/src/docs-overview/avocado-desktop/overview.mdx
+++ b/src/docs-overview/avocado-desktop/overview.mdx
@@ -14,7 +14,7 @@ Avocado Desktop is the native app for building Avocado OS, Peridio's immutable e
   <CalloutButton
     label="Get Avocado Desktop"
     cta="Download →"
-    href="https://www.peridio.com/avocado-os#downloads"
+    href="https://www.peridio.com/downloads#desktop"
   />
 </div>
 
@@ -38,7 +38,7 @@ Avocado Desktop is the native app for building Avocado OS, Peridio's immutable e
 
 Avocado Desktop is available for macOS today, and it self-updates in place once installed — you don't re-download it for new releases. Windows and Linux builds are on the way.
 
-1. **Install the app** — download the [macOS release](https://www.peridio.com/avocado-os#downloads) directly, or install it with Homebrew: `brew install --cask avocado-linux/tap/avocado-desktop`. Avocado Desktop requires macOS 13.0 (Ventura) or later.
+1. **Install the app** — download the [macOS release](https://www.peridio.com/downloads#desktop) directly, or install it with Homebrew: `brew install --cask avocado-linux/tap/avocado-desktop`. Avocado Desktop requires macOS 13.0 (Ventura) or later.
 2. **Open a project** — point Desktop at a new or existing Avocado project. The build VM and toolchain are bundled, so there's nothing else to set up.
 3. **Build and provision** — describe what you want to the agent, or run the build and provisioning steps yourself, then flash your first device to verify the loop end to end.
 

--- a/src/docusaurus.config.js
+++ b/src/docusaurus.config.js
@@ -61,10 +61,14 @@ const config = {
           // Avocado Connect is the successor to Peridio Core; keep old bookmarks alive.
           { from: '/peridio-core/overview', to: '/avocado-connect/overview' },
           { from: '/peridio-core', to: '/avocado-connect/overview' },
-          // The Download & Install page was retired in favor of the Desktop overview.
+          // The Download & Install page was retired. It used to point at the
+          // Desktop overview, which meant a URL literally named `download` landed
+          // on prose describing the app instead of anywhere you could get it.
+          // The CLI installation page is the in-docs handover point, and it links
+          // on to the full artifact list on peridio.com/downloads.
           {
             from: '/developer-reference/getting-started/download',
-            to: '/avocado-desktop/overview',
+            to: '/developer-reference/avocado-cli/installation',
           },
         ],
       },

--- a/src/scripts/sync-references.js
+++ b/src/scripts/sync-references.js
@@ -113,10 +113,13 @@ function rewriteRelativeLinks(body, name) {
 // 404s, not only the avocado-cli one. Absolute URLs are invisible to
 // Docusaurus's broken-link check, so the rewrite has to cover the prefix class.
 //
-// Order matters: the prefix rule runs first, then overview → installation, so
-// both `/guides/avocado-cli/overview` and `/developer-reference/avocado-cli/overview`
-// land on the install page. Site-absolute `/hardware/...` links are a different
-// plugin and are left untouched.
+// Destinations are site-root-relative so preview, staging, and local builds
+// stay on the current host. Order matters: production-domain URLs collapse to
+// `/developer-reference/` first, then overview → installation, so both
+// `/guides/avocado-cli/overview` and `/developer-reference/avocado-cli/overview`
+// (with an optional trailing slash, query, or fragment) land on the install
+// page. Site-absolute `/hardware/...` links are a different plugin and are
+// left untouched.
 //
 // This runs here rather than as a one-time pass over docs-guides/references/
 // because those files are generated: editing them is undone by the next sync.
@@ -125,12 +128,12 @@ function rewriteRelativeLinks(body, name) {
 // ever fixed, these rules simply stop matching.
 const ACQUISITION_REWRITES = [
   {
-    from: /https:\/\/docs\.peridio\.com\/guides\//g,
-    to: 'https://docs.peridio.com/developer-reference/',
+    from: /https:\/\/docs\.peridio\.com\/(?:guides|developer-reference)\//g,
+    to: '/developer-reference/',
   },
   {
-    from: /https:\/\/docs\.peridio\.com\/developer-reference\/avocado-cli\/overview/g,
-    to: 'https://docs.peridio.com/developer-reference/avocado-cli/installation',
+    from: /\/developer-reference\/avocado-cli\/overview\/?([?#][^)\s]*)?(?=[)\s]|$)/g,
+    to: '/developer-reference/avocado-cli/installation$1',
   },
 ]
 
@@ -143,9 +146,10 @@ function rewriteAcquisitionLinks(body) {
     .map((seg, i) => {
       if (i % 2 === 1) return seg
       return ACQUISITION_REWRITES.reduce((acc, rule) => {
-        return acc.replace(rule.from, () => {
+        return acc.replace(rule.from, (...args) => {
           count++
-          return rule.to
+          const groups = args.slice(1, -2)
+          return rule.to.replace(/\$(\d+)/g, (_, n) => groups[Number(n) - 1] ?? '')
         })
       }, seg)
     })
@@ -167,7 +171,7 @@ function processGettingStarted(content, name) {
   // Point "install the CLI" prerequisites at the install page, not the overview
   const { body: repointed, count: acquisitionCount } = rewriteAcquisitionLinks(rewritten)
   if (acquisitionCount > 0) {
-    console.log(`  ${name}: repointed ${acquisitionCount} docs.peridio.com URL(s)`)
+    console.log(`  ${name}: applied ${acquisitionCount} acquisition rewrite(s)`)
   }
   return repointed
 }

--- a/src/scripts/sync-references.js
+++ b/src/scripts/sync-references.js
@@ -108,9 +108,15 @@ function rewriteRelativeLinks(body, name) {
 // ── Repoint acquisition links at the page that hands over the artifact ────────
 // Every reference's getting_started.md lists the Avocado CLI as a prerequisite
 // and links it to the CLI *overview* — a page describing what the CLI does, with
-// no way to obtain it. Two spellings are in the wild upstream, and the `/guides/`
-// one 404s outright because that path prefix was retired in favor of
-// `/developer-reference/`.
+// no way to obtain it. The `/guides/` prefix was retired in favor of
+// `/developer-reference/`, so any absolute `docs.peridio.com/guides/...` URL
+// 404s, not only the avocado-cli one. Absolute URLs are invisible to
+// Docusaurus's broken-link check, so the rewrite has to cover the prefix class.
+//
+// Order matters: the prefix rule runs first, then overview → installation, so
+// both `/guides/avocado-cli/overview` and `/developer-reference/avocado-cli/overview`
+// land on the install page. Site-absolute `/hardware/...` links are a different
+// plugin and are left untouched.
 //
 // This runs here rather than as a one-time pass over docs-guides/references/
 // because those files are generated: editing them is undone by the next sync.
@@ -119,8 +125,8 @@ function rewriteRelativeLinks(body, name) {
 // ever fixed, these rules simply stop matching.
 const ACQUISITION_REWRITES = [
   {
-    from: /https:\/\/docs\.peridio\.com\/guides\/avocado-cli\/overview/g,
-    to: 'https://docs.peridio.com/developer-reference/avocado-cli/installation',
+    from: /https:\/\/docs\.peridio\.com\/guides\//g,
+    to: 'https://docs.peridio.com/developer-reference/',
   },
   {
     from: /https:\/\/docs\.peridio\.com\/developer-reference\/avocado-cli\/overview/g,
@@ -161,7 +167,7 @@ function processGettingStarted(content, name) {
   // Point "install the CLI" prerequisites at the install page, not the overview
   const { body: repointed, count: acquisitionCount } = rewriteAcquisitionLinks(rewritten)
   if (acquisitionCount > 0) {
-    console.log(`  ${name}: repointed ${acquisitionCount} CLI link(s) → installation`)
+    console.log(`  ${name}: repointed ${acquisitionCount} docs.peridio.com URL(s)`)
   }
   return repointed
 }

--- a/src/scripts/sync-references.js
+++ b/src/scripts/sync-references.js
@@ -105,6 +105,48 @@ function rewriteRelativeLinks(body, name) {
   return { body: out, count }
 }
 
+// ── Repoint acquisition links at the page that hands over the artifact ────────
+// Every reference's getting_started.md lists the Avocado CLI as a prerequisite
+// and links it to the CLI *overview* — a page describing what the CLI does, with
+// no way to obtain it. Two spellings are in the wild upstream, and the `/guides/`
+// one 404s outright because that path prefix was retired in favor of
+// `/developer-reference/`.
+//
+// This runs here rather than as a one-time pass over docs-guides/references/
+// because those files are generated: editing them is undone by the next sync.
+// We only have read access to avocado-linux/references, so the durable place to
+// correct the destination is the seam the content passes through. If upstream is
+// ever fixed, these rules simply stop matching.
+const ACQUISITION_REWRITES = [
+  {
+    from: /https:\/\/docs\.peridio\.com\/guides\/avocado-cli\/overview/g,
+    to: 'https://docs.peridio.com/developer-reference/avocado-cli/installation',
+  },
+  {
+    from: /https:\/\/docs\.peridio\.com\/developer-reference\/avocado-cli\/overview/g,
+    to: 'https://docs.peridio.com/developer-reference/avocado-cli/installation',
+  },
+]
+
+function rewriteAcquisitionLinks(body) {
+  let count = 0
+  // Same fenced-code split as rewriteRelativeLinks: a URL shown inside an
+  // example is being quoted, not offered as a link to follow.
+  const segments = body.split(/(```[\s\S]*?```|~~~[\s\S]*?~~~)/g)
+  const out = segments
+    .map((seg, i) => {
+      if (i % 2 === 1) return seg
+      return ACQUISITION_REWRITES.reduce((acc, rule) => {
+        return acc.replace(rule.from, () => {
+          count++
+          return rule.to
+        })
+      }, seg)
+    })
+    .join('')
+  return { body: out, count }
+}
+
 // ── Strip H1 and img tags from getting_started body ───────────────────────────
 function processGettingStarted(content, name) {
   // Remove inline <img> tags
@@ -116,7 +158,12 @@ function processGettingStarted(content, name) {
   if (count > 0) {
     console.log(`  ${name}: rewrote ${count} relative link(s) → GitHub`)
   }
-  return rewritten
+  // Point "install the CLI" prerequisites at the install page, not the overview
+  const { body: repointed, count: acquisitionCount } = rewriteAcquisitionLinks(rewritten)
+  if (acquisitionCount > 0) {
+    console.log(`  ${name}: repointed ${acquisitionCount} CLI link(s) → installation`)
+  }
+  return repointed
 }
 
 // ── Parse a reference folder ──────────────────────────────────────────────────

--- a/src/src/components/shared/HostPrerequisites.tsx
+++ b/src/src/components/shared/HostPrerequisites.tsx
@@ -12,16 +12,21 @@ export default function HostPrerequisites() {
       <ul>
         <li>
           <strong>macOS</strong> — install the{' '}
-          <Link to="/developer-reference/avocado-cli/overview">Avocado CLI</Link> and{' '}
+          <Link to="/developer-reference/avocado-cli/installation">Avocado CLI</Link> and{' '}
           <Link href="https://www.docker.com/products/docker-desktop/">Docker Desktop</Link>,{' '}
-          <strong>or</strong> install <Link to="/avocado-desktop/overview">Avocado Desktop</Link>,
-          which bundles the build VM and toolchain — no Docker Desktop required.
+          <strong>or</strong> install{' '}
+          <Link href="https://www.peridio.com/downloads#desktop">Avocado Desktop</Link>, which
+          bundles the build VM and toolchain — no Docker Desktop required.
         </li>
         <li>
           <strong>Linux</strong> — install the{' '}
-          <Link to="/developer-reference/avocado-cli/overview">Avocado CLI</Link> and{' '}
+          <Link to="/developer-reference/avocado-cli/installation">Avocado CLI</Link> and{' '}
           <Link href="https://www.docker.com/products/docker-desktop/">Docker Desktop</Link>.
           (Avocado Desktop is macOS-only today.)
+        </li>
+        <li>
+          Every shipping CLI build, with its size and SHA-256, is listed on{' '}
+          <Link href="https://www.peridio.com/downloads#cli-artifacts">Downloads</Link>.
         </li>
       </ul>
     </Admonition>


### PR DESCRIPTION
Fixes DES-312 — https://linear.app/peridio/issue/DES-312/fix-download-entry-points-that-resolve-to-descriptions-instead-of

## The report

> The Getting Started with Jetson page does not link to downloads at all, and the Avocado CLI link resolves to a description of what Avocado CLI is rather than to where to get it.

Both halves check out, and the pattern is wider than the one page.

## Root cause

[`a3d4eae`](https://github.com/peridio/docs/commit/a3d4eae02a48043f5a5d19e0abb63c81f98511e5) retired the docs "Download & Install" page and redirected it to the Desktop **overview**. From then on a URL literally named `download` resolved to prose about the app, and the acquisition links in the guides were all written against overview pages.

## What was wrong

| Where | Link | Landed on |
|---|---|---|
| `shared/HostPrerequisites.tsx` ×2 | "install the **Avocado CLI**" | `/avocado-cli/overview` — describes the CLI, offers no way to get it, not even an inline link to the install page |
| `shared/HostPrerequisites.tsx` | "install **Avocado Desktop**" | `/avocado-desktop/overview` |
| 28 generated `references/*.mdx` | same CLI prerequisite | `docs.peridio.com/guides/avocado-cli/overview` — **404**, the `/guides/` prefix was retired |
| `getting-started/index.mdx` | CTA "Avocado Desktop" | `/avocado-desktop/overview` |
| redirects | `/developer-reference/getting-started/download` | `/avocado-desktop/overview` |
| `avocado-desktop/overview.mdx` ×2 | "Download →" / "macOS release" | `peridio.com/avocado-os#downloads`, the pre-`/downloads` anchor |

Nothing on the docs site linked to `peridio.com/downloads` anywhere — `grep` returned zero hits.

## What changed

- **`HostPrerequisites` is the single component all four getting-started surfaces render** (Jetson, QEMU, Raspberry Pi, and the Any-Supported-Target selector), so that is where the fix lands rather than in four call sites: both CLI links now resolve to the installation page, "install Avocado Desktop" resolves to the download, and the artifact list is named alongside them.
- **The 28 generated reference guides are fixed in `sync-references.js`, not in the files.** They are gitignored build output generated from `avocado-linux/references`, so editing them does not persist, and we have read-only access upstream. The rewrite sits next to the existing relative-link pass — same class of problem, same seam — so it survives every resync and lapses on its own if upstream is corrected.
- `/getting-started/download` now redirects to the CLI installation page.
- Desktop acquisition links moved to `/downloads#desktop`.
- The CLI overview page now says where to get the CLI, so the links that legitimately point at it for description no longer dead-end.
- The MCP prerequisite offers the install page directly instead of routing through the getting-started index.

**Left alone deliberately:** the tool-choice links in `provisioning.md` and `mcp/installation.md` point at overview pages to say what a tool *is*, which is the right destination for those sentences — and both overviews now route onward to acquisition.

## Verification

- `npm run build` passes, including Docusaurus strict broken-link checking.
- Every prerequisite-style CLI link in the built output resolves to `installation`; none remain on `overview`. The `avocado-cli/overview` hits that remain in the build are `menu__link` sidebar nav, which is correct.
- All four getting-started surfaces reach `/downloads` — `any-target` via the selector, on target selection.
- `npm run lint`, `npm run typecheck`, `npm run format` clean.
- Confirmed the sync rule fires on a real `npm run sync-references`: 28 × `repointed 1 CLI link(s) → installation`.

## ⚠️ Merge order

The `peridio.com/downloads` links **404 until [peridio/apex#120](https://github.com/peridio/apex/pull/120) ships that page**. This PR must land after it.

## Note on red CI

`checks.yml` and the CodeQL `Analyze` jobs fail in 3–5 seconds with **zero steps executed**, which is a job that never started rather than a check that ran. This is pre-existing and repo-wide: every PR-triggered `Checks` run in `peridio/docs` has failed since 2026-08-17 13:43 UTC, including on the unrelated `developer-reference/device-tree-overlays` branch; the last PR-branch success was 2026-08-15. GitHub status is operational, so it looks like an org-level Actions/permissions/quota change. Not caused by this diff — the equivalent checks all pass locally. Worth a separate issue.