### PR TITLE
docs: avocado desktop ships for linux, not macOS only

### DIFF
--- a/src/docs-guides/avocado-cli/installation.md
+++ b/src/docs-guides/avocado-cli/installation.md
@@ -21,7 +21,7 @@ The Linux `*-musl` builds are statically linked, so they do not depend on the ho
 
 The install script picks the appropriate binary automatically. For manual installs, download the matching artifact from the [releases page](https://github.com/avocado-linux/avocado-cli/releases), or use [Downloads](https://www.peridio.com/downloads#cli-artifacts), which lists every shipping build with its size and SHA-256.
 
-Prefer a native app? [Avocado Desktop](https://www.peridio.com/downloads#desktop) bundles the CLI, the build VM, and the cross-compilation toolchain in one install.
+Prefer a native app? [Avocado Desktop](https://www.peridio.com/downloads#desktop) ships for macOS and Linux, carrying the CLI and the cross-compilation toolchain in one install, plus the build VM on macOS. The Arch Linux package (`pacman`) is the exception: it links a CLI you install separately rather than bundling one.
 
 ## Install
 

--- a/src/docs-overview/avocado-desktop/overview.mdx
+++ b/src/docs-overview/avocado-desktop/overview.mdx
@@ -8,7 +8,7 @@ import CalloutButton from '@site/src/components/CalloutButton'
 
 Build and provision Avocado OS from your own machine. Describe what you want in plain English and a built-in AI agent drives the whole toolchain — editing config, cross-compiling, building the image, and writing it to hardware — so you ship a real device without memorizing a single config key.
 
-Avocado Desktop is the native app for building Avocado OS, Peridio's immutable embedded Linux runtime. It bundles the build VM, cross-compilation toolchain, hardware provisioning, and a developer-preview AI agent wired to the Avocado MCP into one workspace that runs locally on your machine.
+Avocado Desktop is the native app for building Avocado OS, Peridio's immutable embedded Linux runtime. It bundles the cross-compilation toolchain, hardware provisioning, and a developer-preview AI agent wired to the Avocado MCP into one workspace that runs locally on your machine. On macOS it also bundles the build VM your images are built in. On Linux it builds with the host's Docker instead.
 
 <div style={{ marginBottom: '1.75rem' }}>
   <CalloutButton
@@ -36,10 +36,12 @@ Avocado Desktop is the native app for building Avocado OS, Peridio's immutable e
 
 ## Getting Started
 
-Avocado Desktop is available for macOS today, and it self-updates in place once installed — you don't re-download it for new releases. Windows and Linux builds are on the way.
+Avocado Desktop is available for macOS and Linux, with a Windows build on the way. On macOS it self-updates in place once installed, so you don't re-download it for new releases. On Linux, each release is installed as a new package.
 
-1. **Install the app** — download the [macOS release](https://www.peridio.com/downloads#desktop) directly, or install it with Homebrew: `brew install --cask avocado-linux/tap/avocado-desktop`. Avocado Desktop requires macOS 13.0 (Ventura) or later.
-2. **Open a project** — point Desktop at a new or existing Avocado project. The build VM and toolchain are bundled, so there's nothing else to set up.
+1. **Install the app** — every build, with its size and publish date, is listed on [Downloads](https://www.peridio.com/downloads#desktop).
+   - **macOS** — take the universal disk image, or install it with Homebrew: `brew install --cask avocado-linux/tap/avocado-desktop`. Requires macOS 13.0 (Ventura) or later.
+   - **Linux** — take the deb, rpm, or pacman package for your distribution. Every build needs WebKitGTK 4.1, which ships on Ubuntu 22.04+, Debian 12+, and current Fedora and Arch, plus Docker, which is where builds run. The pacman package also needs the Avocado CLI installed separately, because it links one rather than bundling it. USB device passthrough needs your distribution's usbip tools.
+2. **Open a project** — point Desktop at a new or existing Avocado project. On macOS the build VM and toolchain are bundled, so there's nothing else to set up. On Linux, install Docker first, because that is where the app runs builds.
 3. **Build and provision** — describe what you want to the agent, or run the build and provisioning steps yourself, then flash your first device to verify the loop end to end.
 
 ---
@@ -86,7 +88,7 @@ Under the hood, the agent is wired to the **Avocado MCP**, a [Model Context Prot
 
 Avocado Desktop cross-compiles your application to the target architecture and assembles a complete image — the parts that are easy to get wrong by hand are handled for you.
 
-- **Bundled build VM** — the build environment ships with the app; no separate SDK install or container setup
+- **Build environment** — on macOS the build VM ships with the app, so there is no separate SDK install or container setup; on Linux the app builds with the host's Docker
 - **Cross-compilation** — produces real target binaries, such as `aarch64-avocado-linux-gnu` ELF executables, not prebuilt drop-ins
 - **Config handled for you** — the SDK toolchain, sysroot-aware compile steps, and `avocado.yaml` are generated and maintained by the agent
 

--- a/src/src/components/shared/HostPrerequisites.tsx
+++ b/src/src/components/shared/HostPrerequisites.tsx
@@ -4,8 +4,19 @@ import Link from '@docusaurus/Link'
 
 // The host toolchain setup shared across every Getting Started surface (the
 // per-target .md/.mdx guides and the TargetSelector on the "Any Supported
-// Target" page). Kept in one place so the macOS two-path story and the Linux
-// path stay consistent and are edited once.
+// Target" page). Kept in one place so both platforms' two-path story stays
+// consistent and is edited once.
+//
+// The two Desktop bullets differ for a reason. On macOS the app bundles its own
+// build VM and needs no Docker; on Linux it drives the host's Docker, so Docker
+// stays a prerequisite on that path. Offering "install Avocado Desktop instead"
+// on Linux would drop a requirement that builds need.
+//
+// The Linux bullet also names two things the macOS one does not need. The pacman
+// package depends on an independently installed avocado-cli, so Desktop is not an
+// alternative to the CLI there the way it is elsewhere, and a reader following
+// the plain "either" would have `pacman -U` refuse on the unmet dependency. And
+// no Linux package pulls in usbip, which USB provisioning needs.
 export default function HostPrerequisites() {
   return (
     <Admonition type="info" title="Choose your setup">
@@ -19,10 +30,14 @@ export default function HostPrerequisites() {
           bundles the build VM and toolchain — no Docker Desktop required.
         </li>
         <li>
-          <strong>Linux</strong> — install the{' '}
-          <Link to="/developer-reference/avocado-cli/installation">Avocado CLI</Link> and{' '}
-          <Link href="https://www.docker.com/products/docker-desktop/">Docker Desktop</Link>.
-          (Avocado Desktop is macOS-only today.)
+          <strong>Linux</strong> — install{' '}
+          <Link href="https://docs.docker.com/engine/install/">Docker</Link> and either the{' '}
+          <Link to="/developer-reference/avocado-cli/installation">Avocado CLI</Link> or{' '}
+          <Link href="https://www.peridio.com/downloads#desktop">Avocado Desktop</Link>, which ships
+          as a deb, rpm, or pacman package. Docker is required either way on Linux: Desktop builds
+          with the host&apos;s Docker rather than the VM it bundles on macOS. The pacman package is
+          the exception to &quot;either&quot;, since it links the Avocado CLI rather than bundling
+          one, so install that too. For USB provisioning, add your distribution&apos;s usbip tools.
         </li>
         <li>
           Every shipping CLI build, with its size and SHA-256, is listed on{' '}


### PR DESCRIPTION
## Summary

Avocado Desktop 1.0.0-rc.7 is the first release cut for Linux as well as macOS, published as a deb, an rpm, and a pacman package. The docs still said "available for macOS today ... Windows and Linux builds are on the way", and the shared getting-started prerequisite told Linux readers verbatim that "Avocado Desktop is macOS-only today". That one component renders on every Getting Started surface, so it was steering Linux readers away from a product that now supports them.

No artifact URLs, sizes, or versions are added here. `peridio.com/downloads` is the catalog and already carries them; these pages link to it rather than growing a second copy to drift.

## Three facts scoped rather than widened

- **Updates.** Tauri's updater replaces a macOS `.app` in place and cannot write over a deb, rpm, or pacman install, so in-place updating stays a macOS feature and Linux takes each release as a new package.
- **The build VM.** On Linux the app builds with the host's Docker and installs no VM, so "the build VM and toolchain are bundled, so there's nothing else to set up" pointed a Linux reader at a build that cannot run until they install Docker.
- **Desktop as an alternative to the CLI.** True of the deb and rpm, which bundle it. The pacman package depends on an independently installed `avocado-cli`, so an Arch reader following the plain "either the CLI or Desktop" would have `pacman -U` refuse on the unmet dependency.

The shared prerequisite also omitted `usbip`, which USB provisioning needs and which no Linux package pulls in. Someone entering through the Raspberry Pi or Jetson guide could satisfy every prerequisite shown and still fail at provisioning.

## Test plan

- `npm run lint` (eslint) and `npm run typecheck` (tsc) clean
- prettier clean on all three files
- `npm run build` succeeds with `onBrokenLinks` and `onBrokenMarkdownLinks` both `throw`
- Rewritten prerequisite verified in the built HTML for the QEMU, Raspberry Pi, and Jetson guides; the fourth surface reaches it through the target selector at runtime
- Swept the repo for surviving macOS-only or Linux-is-coming claims about Desktop; none outside generated output and dated field notes

Depends on peridio/apex#124 only for the `#desktop` anchor content, not for these links to resolve.
