### PR TITLE
docs: publish desktop 1.0.0-rc.7 release notes

### DIFF
--- a/src/docs-changelog/august-2026/desktop-1.0.0-rc.7.md
+++ b/src/docs-changelog/august-2026/desktop-1.0.0-rc.7.md
@@ -1,0 +1,37 @@
+---
+title: 'Desktop: 1.0.0-rc.7'
+description: 'Avocado Desktop 1.0.0-rc.7 release notes: native Linux support with installable packages, and a tabbed terminal.'
+---
+
+rc.7 is the Linux release. Avocado Desktop now runs natively on Linux, and every
+release publishes installable Linux packages alongside the macOS disk image.
+
+## Linux support
+
+The app runs natively on Linux with direct USB passthrough, so provisioning real
+hardware needs no VM. Releases publish three packages, all x86_64:
+
+- **`.deb`** — Ubuntu and Debian.
+- **`.rpm`** — the Fedora family.
+- **A pacman-installable package** — Arch, installed with `pacman -U`.
+
+Every build needs WebKitGTK 4.1, which ships on Ubuntu 22.04+, Debian 12+, and
+current Fedora and Arch. Builds run on the host's Docker rather than in the
+bundled VM that macOS uses, so Docker has to be installed. USB passthrough also
+needs your distribution's usbip tools.
+
+Two differences from macOS worth knowing before you install:
+
+- **Updates** — the macOS app replaces itself in place; the Linux packages do
+  not, so a new release is installed as a new package.
+- **The Arch package links the Avocado CLI rather than bundling one** — install
+  `avocado-cli` first. The `.deb` and `.rpm` carry the toolchain themselves.
+
+Every artifact, with its size and publish date, is listed on
+[Downloads](https://www.peridio.com/downloads#desktop).
+
+## Tabbed terminal
+
+UART, SSH, QEMU, and local shell sessions now open as tabs in a single pane
+instead of replacing one another, so a serial console and a shell can stay open
+side by side while a build runs.

--- a/src/docs-changelog/latest.mdx
+++ b/src/docs-changelog/latest.mdx
@@ -6,4 +6,4 @@ displayed_sidebar: changelog
 
 import { Redirect } from '@docusaurus/router'
 
-<Redirect to="/changelog/july-2026/reference-2026.07" />
+<Redirect to="/changelog/august-2026/desktop-1.0.0-rc.7" />

--- a/src/sidebars-changelog.js
+++ b/src/sidebars-changelog.js
@@ -5,6 +5,13 @@ const sidebars = {
   changelog: [
     {
       type: 'category',
+      label: 'August 2026',
+      collapsible: false,
+      collapsed: false,
+      items: ['august-2026/desktop-1.0.0-rc.7'],
+    },
+    {
+      type: 'category',
       label: 'July 2026',
       collapsible: false,
       collapsed: false,

--- a/src/src/components/ChangelogInfiniteScroll/changelogEntries.js
+++ b/src/src/components/ChangelogInfiniteScroll/changelogEntries.js
@@ -1,5 +1,7 @@
 // Static imports of all changelog entries, ordered newest-first to match sidebars-changelog.js
 
+// -- August 2026 --
+import DESKTOP_1_0_0_RC_7 from '../../../docs-changelog/august-2026/desktop-1.0.0-rc.7.md'
 // -- July 2026 --
 import REF_2026_07 from '../../../docs-changelog/july-2026/reference-2026.07.md'
 import DESKTOP_1_0_0_RC_6 from '../../../docs-changelog/july-2026/desktop-1.0.0-rc.6.md'
@@ -77,6 +79,14 @@ export const PRODUCTS = [
  * Entries without an explicit `product` are CLI releases.
  */
 const rawEntries = [
+  {
+    product: 'desktop',
+    version: '1.0.0-rc.7',
+    monthSlug: 'august-2026',
+    monthLabel: 'August 2026',
+    permalink: '/changelog/august-2026/desktop-1.0.0-rc.7',
+    Component: DESKTOP_1_0_0_RC_7,
+  },
   {
     product: 'reference',
     version: '2026.07',


### PR DESCRIPTION
## Summary

Avocado Desktop 1.0.0-rc.7 shipped on 2026-08-18 with no public release notes. The newest Desktop entry was rc.6, while `peridio.com/downloads` already advertises rc.7 and its Linux packages, so the two surfaces disagreed about what the current release is.

## Scope of the entry

Two headline additions rather than a mirror of the full changelog, which lists five additions, two changes, and about a dozen fixes:

- **Linux support** — native Linux with direct USB passthrough and no VM, plus installable `.deb`, `.rpm`, and pacman packages
- **Tabbed terminal** — UART, SSH, QEMU, and local shell sessions in one pane

The entry also carries the three platform caveats the download page states, so a reader gets the same story from either surface: in-place updating is macOS-only, Linux builds with the host's Docker rather than a bundled VM, and the Arch package links an independently installed `avocado-cli`.

A new file rather than an extension of the consolidated rc.1–rc.6 page, because renaming that page changes its permalink and would need a redirect to keep existing links alive. This adds the first `august-2026` month directory.

## Why four files

Publishing one entry means registering it in three places, none of which is enforced by a test or by `scripts/checks.sh`:

- the markdown file under `docs-changelog/<month>/`
- an import **and** a `rawEntries` object in `ChangelogInfiniteScroll/changelogEntries.js` — miss this and the page exists but never appears in the feed, with nothing failing
- a category and item in `sidebars-changelog.js`

`latest.mdx` is the fourth. It is a hand-pinned `<Redirect>` rather than anything computed, and it was still sending `/changelog/latest` to a July *references* entry.

## Test plan

Verified in the built output rather than by inspection:

- page renders at `changelog/august-2026/desktop-1.0.0-rc.7`
- its permalink appears in the infinite-scroll feed bundles, confirming the registration took
- the sidebar shows the `August 2026` category, and newest-first ordering holds in all three files
- `latest.html` redirects to the new entry
- the rc.6 page still resolves at its old permalink
- no PR numbers or other private-repo detail in the copy, and no AppImage reference

eslint, tsc, and prettier clean; `npm run build` passes with `onBrokenLinks` and `onBrokenMarkdownLinks` both set to `throw`.

Cross-reviewed with GPT-5.6 (plan mode, read-only): zero findings, approve.

## Follow-up worth its own issue

The three-file registration with no enforcement is what let this get missed. A guard in `scripts/checks.sh` asserting every file under `docs-changelog/*/` has a matching `changelogEntries.js` entry and sidebar line would catch the whole class.
