### PR TITLE
Name the Linux upgrade action instead of "installed as a new package"

### DIFF
--- a/src/docs-changelog/august-2026/desktop-1.0.0-rc.7.md
+++ b/src/docs-changelog/august-2026/desktop-1.0.0-rc.7.md
@@ -23,7 +23,7 @@ needs your distribution's `usbip` tools.
 Two differences from macOS worth knowing before you install:
 
 - **Updates** — the macOS app replaces itself in place; the Linux packages do
-  not, so upgrade them through your package manager.
+  not. Upgrade them through your package manager.
 - **The Arch package links the Avocado CLI rather than bundling one** — install
   `avocado-cli` first. The `.deb` and `.rpm` carry the toolchain themselves.
 

--- a/src/docs-changelog/august-2026/desktop-1.0.0-rc.7.md
+++ b/src/docs-changelog/august-2026/desktop-1.0.0-rc.7.md
@@ -18,12 +18,12 @@ hardware needs no VM. Releases publish three packages, all x86_64:
 Every build needs WebKitGTK 4.1, which ships on Ubuntu 22.04+, Debian 12+, and
 current Fedora and Arch. Builds run on the host's Docker rather than in the
 bundled VM that macOS uses, so Docker has to be installed. USB passthrough also
-needs your distribution's usbip tools.
+needs your distribution's `usbip` tools.
 
 Two differences from macOS worth knowing before you install:
 
 - **Updates** — the macOS app replaces itself in place; the Linux packages do
-  not, so a new release is installed as a new package.
+  not, so upgrade them through your package manager.
 - **The Arch package links the Avocado CLI rather than bundling one** — install
   `avocado-cli` first. The `.deb` and `.rpm` carry the toolchain themselves.
 

--- a/src/docs-overview/avocado-desktop/overview.mdx
+++ b/src/docs-overview/avocado-desktop/overview.mdx
@@ -40,7 +40,7 @@ Avocado Desktop is available for macOS and Linux, with a Windows build on the wa
 
 1. **Install the app** — every build, with its size and publish date, is listed on [Downloads](https://www.peridio.com/downloads#desktop).
    - **macOS** — take the universal disk image, or install it with Homebrew: `brew install --cask avocado-linux/tap/avocado-desktop`. Requires macOS 13.0 (Ventura) or later.
-   - **Linux** — take the deb, rpm, or pacman package for your distribution. Every build needs WebKitGTK 4.1, which ships on Ubuntu 22.04+, Debian 12+, and current Fedora and Arch, plus Docker, which is where builds run. The pacman package also needs the Avocado CLI installed separately, because it links one rather than bundling it. USB device passthrough needs your distribution's usbip tools.
+   - **Linux** — take the deb, rpm, or pacman package for your distribution. Every build needs WebKitGTK 4.1, which ships on Ubuntu 22.04+, Debian 12+, and current Fedora and Arch, plus Docker, which is where builds run. The pacman package also needs the Avocado CLI installed separately, because it links one rather than bundling it. USB device passthrough needs your distribution's `usbip` tools.
 2. **Open a project** — point Desktop at a new or existing Avocado project. On macOS the build VM and toolchain are bundled, so there's nothing else to set up. On Linux, install Docker first, because that is where the app runs builds.
 3. **Build and provision** — describe what you want to the agent, or run the build and provisioning steps yourself, then flash your first device to verify the loop end to end.
 

--- a/src/docs-overview/avocado-desktop/overview.mdx
+++ b/src/docs-overview/avocado-desktop/overview.mdx
@@ -36,7 +36,7 @@ Avocado Desktop is the native app for building Avocado OS, Peridio's immutable e
 
 ## Getting Started
 
-Avocado Desktop is available for macOS and Linux, with a Windows build on the way. On macOS it self-updates in place once installed, so you don't re-download it for new releases. On Linux, each release is installed as a new package.
+Avocado Desktop is available for macOS and Linux, with a Windows build on the way. On macOS it self-updates in place once installed, so you don't re-download it for new releases. On Linux the packages don't self-update; download the new release and upgrade it through your package manager.
 
 1. **Install the app** — every build, with its size and publish date, is listed on [Downloads](https://www.peridio.com/downloads#desktop).
    - **macOS** — take the universal disk image, or install it with Homebrew: `brew install --cask avocado-linux/tap/avocado-desktop`. Requires macOS 13.0 (Ventura) or later.

--- a/src/src/components/shared/HostPrerequisites.tsx
+++ b/src/src/components/shared/HostPrerequisites.tsx
@@ -37,7 +37,8 @@ export default function HostPrerequisites() {
           as a deb, rpm, or pacman package. Docker is required either way on Linux: Desktop builds
           with the host&apos;s Docker rather than the VM it bundles on macOS. The pacman package is
           the exception to &quot;either&quot;, since it links the Avocado CLI rather than bundling
-          one, so install that too. For USB provisioning, add your distribution&apos;s usbip tools.
+          one, so install that too. For USB provisioning, add your distribution&apos;s{' '}
+          <code>usbip</code> tools.
         </li>
         <li>
           Every shipping CLI build, with its size and SHA-256, is listed on{' '}


### PR DESCRIPTION
## Description

Both docs surfaces that tell a Linux reader how Avocado Desktop takes a new release said the release "is installed as a new package". That reads as the new version co-installing beside the old one. It does not: a newer `.deb`, `.rpm`, or pacman package upgrades the existing install. Both now name the action, which is to upgrade through the package manager.

Raised by Copilot on #486 and left for a follow-up on purpose — the same sentence appeared on three surfaces (the two here plus the "Do I need to re-download" FAQ on www.peridio.com), so correcting one would have recreated the drift #486 was closing.

- `src/docs-overview/avocado-desktop/overview.mdx`, the Getting Started intro — "On Linux, each release is installed as a new package." → "On Linux the packages don't self-update; download the new release and upgrade it through your package manager."
- `src/docs-changelog/august-2026/desktop-1.0.0-rc.7.md`, the **Updates** bullet — "…the Linux packages do not, so a new release is installed as a new package." → "…the Linux packages do not. Upgrade them through your package manager."
- `usbip` is now code-formatted everywhere a reader sees it: inline code in the rc.7 entry (matching `pacman -U`, `.deb`, `.rpm`, and `avocado-cli` there), in the `overview.mdx` Linux install bullet, and as `<code>usbip</code>` in `src/src/components/shared/HostPrerequisites.tsx`, which renders on the QEMU, Raspberry Pi, Jetson, and target-selector surfaces — the places a reader is actually told to install it. Verified in the build output: code-wrapped on all five pages that mention it, none bare.

The changelog entry is a dated release note, so this is a wording correction only — nothing is restructured.

Deliberately not "no auto-update on Linux yet": the "yet" implies a roadmap that does not exist. Tauri's updater can replace an AppImage, but that artifact is not published on the download page.

Companion PR for the third surface: peridio/apex#125

DES-319

## Checklist

- [x] I have read the [Contributing guidelines](../CONTRIBUTING.md).
- [x] I have the right to submit this contribution, and I agree it is licensed to
      Peridio, Inc. as described in the Contributing guidelines.
- [x] This contribution contains no third-party personal data and nothing
      defamatory, infringing, or unlawful.
- [x] I ran the project checks (`bash scripts/checks.sh`) and they pass.


